### PR TITLE
Set empty sku not as new

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product/Type/Simple.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product/Type/Simple.php
@@ -47,6 +47,9 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product_Type_Simple
      */
     protected function _isSkuNew($sku)
     {
+        if ($sku == '') {
+            return false;
+        }
         $oldSkus = $this->_entityModel->getOldSku();
         return !isset($oldSkus[$sku]);
     }


### PR DESCRIPTION
Bug in update of an existing products over multiple store views.

| sku | _type | _attribute_set | _store | name | description | short_description |
| --- | --- | --- | --- | --- | --- | --- |
| existing_sku | simple | Default |  | foo | foo | foo |
|  |  |  | de | bar | bar | bar |
|  |  |  | en | zoz | zoz | zoz |

\AvS_FastSimpleImport_Model_Import_Entity_Product_Type_Simple::_isSkuNew method will return _true_ for second and third row. 
Magento will init a new product and add default values of attribute if set.
In my case i trigger the import method twice in a script. The first import adds new products and set some flags with yes/no options. The second import will "reinit" the values with the default value "0".
So the second import overwrites the values from first one.
