### PR TITLE
Event für InitCategories

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -204,23 +204,30 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends Mage_ImportExport
      */
     protected function _initCategories()
     {
-        $collection = Mage::getResourceModel('catalog/category_collection')->addNameToResult();
-        /* @var $collection Mage_Catalog_Model_Resource_Eav_Mysql4_Category_Collection */
-        foreach ($collection as $category) {
-            $structure = explode('/', $category->getPath());
-            $pathSize = count($structure);
-            if ($pathSize > 2) {
-                $path = array();
-                $this->_categories[implode('/', $path)] = $category->getId();
-                for ($i = 1; $i < $pathSize; $i++) {
-                    $path[] = $collection->getItemById($structure[$i])->getName();
-                }
+        $transportObject = new Varien_Object();
+        Mage::dispatchEvent( 'avs_fastsimpleimport_entity_product_init_categories', array('transport' => $transportObject) );
 
-                // additional options for category referencing: name starting from base category, or category id
-                $this->_categories[implode('/', $path)] = $category->getId();
-                array_shift($path);
-                $this->_categories[implode('/', $path)] = $category->getId();
-                $this->_categories[$category->getId()] = $category->getId();
+        if ( $transportObject->getCategories() ) {
+            $this->_categories = $transportObject->getCategories();
+        } else {
+            $collection = Mage::getResourceModel('catalog/category_collection')->addNameToResult();
+            /* @var $collection Mage_Catalog_Model_Resource_Eav_Mysql4_Category_Collection */
+            foreach ($collection as $category) {
+                $structure = explode('/', $category->getPath());
+                $pathSize = count($structure);
+                if ($pathSize > 2) {
+                    $path = array();
+                    $this->_categories[implode('/', $path)] = $category->getId();
+                    for ($i = 1; $i < $pathSize; $i++) {
+                        $path[] = $collection->getItemById($structure[$i])->getName();
+                    }
+
+                    // additional options for category referencing: name starting from base category, or category id
+                    $this->_categories[implode('/', $path)] = $category->getId();
+                    array_shift($path);
+                    $this->_categories[implode('/', $path)] = $category->getId();
+                    $this->_categories[$category->getId()] = $category->getId();
+                }
             }
         }
         return $this;


### PR DESCRIPTION
In der Regel haben wir auf Category-Ebene ein neues Attribute welche ERP_ID heißt. Auf Basis dieser ID erhalten wir häufig auch die Zuordnungen der Produkte zu einer Kategorie.

Über das neue Event kann man initCategories neu definieren und so recht einfach ein eigenes mapping integrieren ohne das Core-Modul überschreiben zu müssen.
