### PR TITLE
allowed to have more than the standard 3 images assigned during import

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import.php
@@ -33,6 +33,7 @@ class AvS_FastSimpleImport_Model_Import extends Mage_ImportExport_Model_Import
         $this->setDropdownAttributes(array());
         $this->setMultiselectAttributes(array());
         $this->setAllowRenameFiles(true);
+        $this->setImageAttributes(array());
     }
 
     /**
@@ -400,6 +401,10 @@ class AvS_FastSimpleImport_Model_Import extends Mage_ImportExport_Model_Import
     {
         if (!is_array($attributeCodes)) {
             $attributeCodes = array($attributeCodes);
+            $attributes = Mage::getResourceModel('catalog/product_attribute_collection')->addFieldToFilter('frontend_input', 'media_image');
+            foreach ($attributes as $attribute) {
+                $attributeCodes[] = $attribute->getAttributeCode();
+            }
         }
         $this->setData('image_attributes', $attributeCodes);
         return $this;

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -38,6 +38,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends Mage_ImportExport
         return $this->_allowRenameFiles;
     }
 
+
     /**
      * Source model setter.
      *


### PR DESCRIPTION
_media_gallery, image, small_image and thumbnail are the hardcoded names that images can get assigned. With this addition you can extend this array with Adapter->setImageAttributes('something') or Adapter->setImageAttributes(array('something', 'some_other_thing').

closed the previous pull request to get a much cleaner one instead
