### PR TITLE
[~BUGFIX] Inserting of image into catalog_product_entity_media_gallery_v...

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -856,7 +856,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends Mage_ImportExport
                     'store_id' => Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID,
                     'label'    => $insertValue['label'],
                     'position' => $insertValue['position'],
-                    'disabled' => $insertValue['disabled']
+		    'disabled' => isset($insertValue['disabled']) ? $insertValue['disabled'] : 0,
                 );
 
                 try {


### PR DESCRIPTION
When inserting images using this branch, the images weren't imported. I added a echo $e->getMessage() on line 866 in AvS_FastSimpleImport_Model_Import_Entity_Product and got this message;

SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'disabled' cannot be null

So I changed line 859 to include a default value of '0' for disabled when it is not found in $insertValue.
