### PR TITLE
Update modman file

### DIFF
--- a/modman
+++ b/modman
@@ -1,2 +1,2 @@
 src/app/code/community/AvS/FastSimpleImport app/code/community/AvS/FastSimpleImport
-src/app/etc/modules/*                       app/etc/modules/
+src/app/etc/modules/AvS_FastSimpleImport.xml                       app/etc/modules/AvS_FastSimpleImport.xml


### PR DESCRIPTION
As we use https://github.com/magento-hackathon/magento-composer-installer, using exact mapping prevents `app/etc/modules` directory being gitignored.
