### PR TITLE
Added Compatibility for Magento 1.7.0

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Helper/Data.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Helper/Data.php
@@ -10,4 +10,21 @@
  */
 
 class AvS_FastSimpleImport_Helper_Data extends Mage_Core_Helper_Abstract
-{}
+{
+    private $magentoVersion = null;
+
+    public function getMagentoVersion() {
+        if ($this->magentoVersion == null) {
+            $magentoVersionInfo = Mage::getVersionInfo();
+
+
+            $this->magentoVersion = $magentoVersionInfo['major'] * 1000 +
+                $magentoVersionInfo['minor'] * 100 +
+                $magentoVersionInfo['revision'] * 10 +
+                $magentoVersionInfo['patch'] * 1;
+
+        }
+
+        return $this->magentoVersion;
+    }
+}

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -787,6 +787,48 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends Mage_ImportExport
     }
 
     /**
+     * Retrieve attribute by specified code
+     *
+     * @param string $code
+     * @return Mage_Eav_Model_Entity_Attribute_Abstract
+     */
+    protected function _getAttribute($code)
+    {
+
+        if (Mage::helper('fastsimpleimport')->getMagentoVersion() >= 1800) {
+            return parent::_getAttribute($code);
+        } else {
+            $attribute = Mage::getSingleton('importexport/import_proxy_product_resource')->getAttribute($code);
+            $backendModelName = (string)Mage::getConfig()->getNode(
+                'global/importexport/import/catalog_product/attributes/' . $attribute->getAttributeCode() . '/backend_model'
+            );
+            if (!empty($backendModelName)) {
+                $attribute->setBackendModel($backendModelName);
+            }
+            return $attribute;
+        }
+
+    }
+
+
+    /**
+     * Retrieve pattern for time formatting
+     *
+     * @return string
+     */
+    protected function _getStrftimeFormat()
+    {
+        if (Mage::helper('fastsimpleimport')->getMagentoVersion() >= 1800) {
+            return parent::_getStrftimeFormat();
+        } else {
+            return Varien_Date::convertZendToStrftime(Varien_Date::DATETIME_INTERNAL_FORMAT, true, true);
+        }
+
+    }
+
+
+
+    /**
      * Prepare attributes data
      *
      * @param array $rowData


### PR DESCRIPTION
Resolved some compatibility issues. in Mangto 1.7.0 Mage_ImportExport_Model_Import_Entity_Product::_getAttribute and Mage_ImportExport_Model_Import_Entity_Product:_getStrftimeFormat() does not exists
