### PR TITLE
fixed format issue if input has % by escaping

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -775,6 +775,8 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends Mage_ImportExport
         }
 
         if (!$valid) {
+            //escape % for sprintf
+            $message = str_replace('%','%%',$message);
             $this->addRowError(Mage::helper('importexport')->__("Invalid value for '%s'") . '. ' . $message, $rowNum, $attrCode);
         } elseif (!empty($attrParams['is_unique'])) {
             if (isset($this->_uniqueAttributes[$attrCode][$rowData[$attrCode]])) {


### PR DESCRIPTION
If an input field already has % in the string, after sprintf the error message will look like
array[0 => 1]

This str_replace escapes it and fixes the issue.
