### PR TITLE
Allow category entity ids to be used instead of paths while importing products

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -971,11 +971,11 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends Mage_ImportExport
                     $categoryId = $this->_categoriesWithRoots[$rowData[self::COL_ROOT_CATEGORY]][$categoryPath];
                     $categories[$rowSku][$categoryId] = true;
                 } elseif (!empty($categoryPath)) {
-		            if(is_numeric($categoryPath)) {
-		                $categories[$rowSku][$categoryPath] = true; 
-		            } else { 
-                       $categories[$rowSku][$this->_categories[$categoryPath]] = true;
-		            }
+                    if (is_numeric($categoryPath)) {
+                        $categories[$rowSku][$categoryPath] = true;
+                    } else {
+                        $categories[$rowSku][$this->_categories[$categoryPath]] = true;
+                    }
                 } elseif (isset($rowData[self::COL_CATEGORY])) {
                     $categories[$rowSku] = array();
                 }

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -971,7 +971,11 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends Mage_ImportExport
                     $categoryId = $this->_categoriesWithRoots[$rowData[self::COL_ROOT_CATEGORY]][$categoryPath];
                     $categories[$rowSku][$categoryId] = true;
                 } elseif (!empty($categoryPath)) {
-                    $categories[$rowSku][$this->_categories[$categoryPath]] = true;
+		            if(is_numeric($categoryPath)) {
+		                $categories[$rowSku][$categoryPath] = true; 
+		            } else { 
+                       $categories[$rowSku][$this->_categories[$categoryPath]] = true;
+		            }
                 } elseif (isset($rowData[self::COL_CATEGORY])) {
                     $categories[$rowSku] = array();
                 }


### PR DESCRIPTION
Added if loop to allow using category entity ids instead of paths to set categories while importing products using nested arrays
