### PR TITLE
Replaced entity adapter creation to be compatible with current importexport module.

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import.php
@@ -75,7 +75,8 @@ class AvS_FastSimpleImport_Model_Import extends Mage_ImportExport_Model_Import
         $partialIndexing = $this->getPartialIndexing();
 
         /** @var $entityAdapter AvS_FastSimpleImport_Model_Import_Entity_Product */
-        $entityAdapter = Mage::getModel('fastsimpleimport/import_entity_product');
+        $validTypes = Mage_ImportExport_Model_Config::getModels(Mage_ImportExport_Model_Import::CONFIG_KEY_ENTITIES);
+        $entityAdapter = Mage::getModel($validTypes[$this->getEntity()]['model']);
         $entityAdapter->setBehavior($this->getBehavior());
         $entityAdapter->setIsDryrun(false);
         $entityAdapter->setErrorLimit($this->getErrorLimit());

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import.php
@@ -142,7 +142,8 @@ class AvS_FastSimpleImport_Model_Import extends Mage_ImportExport_Model_Import
         $this->setEntity(Mage_Catalog_Model_Product::ENTITY);
 
         /** @var $entityAdapter AvS_FastSimpleImport_Model_Import_Entity_Product */
-        $entityAdapter = Mage::getModel('fastsimpleimport/import_entity_product');
+        $validTypes = Mage_ImportExport_Model_Config::getModels(Mage_ImportExport_Model_Import::CONFIG_KEY_ENTITIES);
+        $entityAdapter = Mage::getModel($validTypes[$this->getEntity()]['model']);
         $entityAdapter->setBehavior($this->getBehavior());
         $entityAdapter->setIsDryRun(true);
         $entityAdapter->setErrorLimit($this->getErrorLimit());
@@ -179,7 +180,8 @@ class AvS_FastSimpleImport_Model_Import extends Mage_ImportExport_Model_Import
         $this->setEntity('customer');
 
         /** @var $entityAdapter AvS_FastSimpleImport_Model_Import_Entity_Customer */
-        $entityAdapter = Mage::getModel('fastsimpleimport/import_entity_customer');
+        $validTypes = Mage_ImportExport_Model_Config::getModels(Mage_ImportExport_Model_Import::CONFIG_KEY_ENTITIES);
+        $entityAdapter = Mage::getModel($validTypes[$this->getEntity()]['model']);
         $entityAdapter->setBehavior($this->getBehavior());
         $entityAdapter->setIgnoreDuplicates($this->getIgnoreDuplicates());
         $entityAdapter->setErrorLimit($this->getErrorLimit());
@@ -232,7 +234,8 @@ class AvS_FastSimpleImport_Model_Import extends Mage_ImportExport_Model_Import
         $this->setEntity('customer');
 
         /** @var $entityAdapter AvS_FastSimpleImport_Model_Import_Entity_Customer */
-        $entityAdapter = Mage::getModel('fastsimpleimport/import_entity_customer');
+        $validTypes = Mage_ImportExport_Model_Config::getModels(Mage_ImportExport_Model_Import::CONFIG_KEY_ENTITIES);
+        $entityAdapter = Mage::getModel($validTypes[$this->getEntity()]['model']);
         $entityAdapter->setBehavior($this->getBehavior());
         $entityAdapter->setErrorLimit($this->getErrorLimit());
         $entityAdapter->setUnsetEmptyFields($this->getUnsetEmptyFields());
@@ -267,7 +270,8 @@ class AvS_FastSimpleImport_Model_Import extends Mage_ImportExport_Model_Import
 
         $partialIndexing = $this->getPartialIndexing();
         /** @var $entityAdapter AvS_FastSimpleImport_Model_Import_Entity_Category */
-        $entityAdapter = Mage::getModel('fastsimpleimport/import_entity_category');
+        $validTypes = Mage_ImportExport_Model_Config::getModels(Mage_ImportExport_Model_Import::CONFIG_KEY_ENTITIES);
+        $entityAdapter = Mage::getModel($validTypes[$this->getEntity()]['model']);
         $entityAdapter->setBehavior($this->getBehavior());
         $entityAdapter->setErrorLimit($this->getErrorLimit());
         $entityAdapter->setIgnoreDuplicates($this->getIgnoreDuplicates());
@@ -328,7 +332,8 @@ class AvS_FastSimpleImport_Model_Import extends Mage_ImportExport_Model_Import
         $this->setEntity(Mage_Catalog_Model_Category::ENTITY);
 
         /** @var $entityAdapter AvS_FastSimpleImport_Model_Import_Entity_Category */
-        $entityAdapter = Mage::getModel('fastsimpleimport/import_entity_category');
+        $validTypes = Mage_ImportExport_Model_Config::getModels(Mage_ImportExport_Model_Import::CONFIG_KEY_ENTITIES);
+        $entityAdapter = Mage::getModel($validTypes[$this->getEntity()]['model']);
         $entityAdapter->setBehavior($this->getBehavior());
         $entityAdapter->setErrorLimit($this->getErrorLimit());
         $entityAdapter->setUnsetEmptyFields($this->getUnsetEmptyFields());

--- a/src/app/code/community/AvS/FastSimpleImport/etc/config.xml
+++ b/src/app/code/community/AvS/FastSimpleImport/etc/config.xml
@@ -29,6 +29,9 @@
 
         <importexport module="importexport">
             <import_entities>
+                <customer translate="label">
+                    <model_token>fastsimpleimport/import_entity_customer</model_token>
+                </customer>
                 <catalog_product translate="label">
                     <model_token>fastsimpleimport/import_entity_product</model_token>
                     <label>Product</label>

--- a/src/app/code/community/AvS/FastSimpleImport/etc/config.xml
+++ b/src/app/code/community/AvS/FastSimpleImport/etc/config.xml
@@ -29,6 +29,10 @@
 
         <importexport module="importexport">
             <import_entities>
+                <catalog_product translate="label">
+                    <model_token>fastsimpleimport/import_entity_product</model_token>
+                    <label>Product</label>
+                </catalog_product>
                 <catalog_category translate="label">
                     <model_token>fastsimpleimport/import_entity_category</model_token>
                     <label>Category</label>

--- a/src/app/etc/modules/AvS_FastSimpleImport.xml
+++ b/src/app/etc/modules/AvS_FastSimpleImport.xml
@@ -4,6 +4,9 @@
 		<AvS_FastSimpleImport>
 			<active>true</active>
 			<codePool>community</codePool>
+			<depends>
+				<Mage_ImportExport/>
+			</depends>
 		</AvS_FastSimpleImport>
 	</modules>
 </config>


### PR DESCRIPTION
Currently the used product entity adapter is hardcoded inside the import model. The correct way is to use the config provided by importeport module.
I patched this for product, category and customer entity. For entity "catalog_product" it must be defined in AVS module.