### PR TITLE
Fix nestedArrayAdapter bug with multiselect values at store-scoped data ...

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -900,7 +900,8 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
 
                 foreach ($attributes as $attributeId => $storeValues) {
                     foreach ($storeValues as $storeId => $storeValue) {
-                        if (! is_null($storeValue)) {
+                        // For storeId 0 we *must* save the NULL value into DB otherwise product collections can not load the store specific values
+                        if ($storeId == 0 || ! is_null($storeValue)) {
                             $tableData[] = array(
                                 'entity_id'      => $productId,
                                 'entity_type_id' => $this->_entityTypeId,

--- a/src/app/code/community/AvS/FastSimpleImport/Model/NestedArrayAdapter.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/NestedArrayAdapter.php
@@ -55,6 +55,11 @@ class AvS_FastSimpleImport_Model_NestedArrayAdapter extends AvS_FastSimpleImport
                         $newLines[$newLineNumber]['sku'] = null;
                         $newLines[$newLineNumber]['_type'] = null;
                         $newLines[$newLineNumber]['_attribute_set'] = null;
+
+                        $originalLineHasStoreScope = isset($line['_store']);
+                        if ($originalLineHasStoreScope) {
+                            $newLines[$newLineNumber]['_store'] = $line['_store'];
+                        }
                     }
                     $newLines[$newLineNumber++][$fieldName] = $singleFieldValue;
                 }


### PR DESCRIPTION
...lines.

All values but the first were lost (well, they were moved into the default scope) since the newly created data lines were not properly associated with the store scope. My solution is to just keep the _store column.