### PR TITLE
1 Change and 1 Feature

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import.php
@@ -91,6 +91,7 @@ class AvS_FastSimpleImport_Model_Import extends Mage_ImportExport_Model_Import
         $entityAdapter->setUnsetEmptyFields($this->getUnsetEmptyFields());
         $entityAdapter->setSymbolEmptyFields($this->getSymbolEmptyFields());
         $entityAdapter->setSymbolIgnoreFields($this->getSymbolIgnoreFields());
+	$entityAdapter->setIgnoreDuplicates($this->getIgnoreDuplicates());
         $this->setEntityAdapter($entityAdapter);
 
         $validationResult = $this->validateSource($data);

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Category.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Category.php
@@ -304,12 +304,13 @@ class AvS_FastSimpleImport_Model_Import_Entity_Category extends Mage_ImportExpor
         $exploded = explode($delimiter, $string);
         $fixed = array();
         for($k = 0, $l = count($exploded); $k < $l; ++$k){
-            if($exploded[$k][strlen($exploded[$k]) - 1] == '\\') {
+            $eIdx = strlen($exploded[$k]) - 1;
+            if($eIdx >= 0 && $exploded[$k][$eIdx] == '\\') {
                 if($k + 1 >= $l) {
                     $fixed[] = trim($exploded[$k]);
                     break;
                 }
-                $exploded[$k][strlen($exploded[$k]) - 1] = $delimiter;
+                $exploded[$k][$eIdx] = $delimiter;
                 $exploded[$k] .= $exploded[$k + 1];
                 array_splice($exploded, $k + 1, 1);
                 --$l;

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -60,6 +60,9 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
     /** @var bool|string */
     protected $_symbolIgnoreFields = false;
 
+    /** @var bool */
+    protected $_ignoreDuplicates = false;
+
     /**
      * Attributes with index (not label) value.
      *
@@ -74,6 +77,17 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
         'custom_design',
         'country_of_manufacture'
     );
+
+    public function setIgnoreDuplicates($ignore)
+    {
+	$this->_ignoreDuplicates = (boolean) $ignore;
+    }
+
+
+    public function getIgnoreDuplicates()
+    {
+	return $this->_ignoreDuplicates;
+    }
 
     /**
      * Set the error limit when the importer will stop
@@ -1330,6 +1344,9 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
         $this->_validatedRows[$rowNum] = true;
 
         if (isset($this->_newSku[$rowData[self::COL_SKU]])) {
+	    if($this->getIgnoreDuplicates()){
+		return true;
+	    }
             $this->addRowError(self::ERROR_DUPLICATE_SKU, $rowNum);
             return false;
         }

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -658,11 +658,10 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
 
             /** @var $attribute Mage_Eav_Model_Entity_Attribute */
             $attribute = Mage::getSingleton('catalog/product')->getResource()->getAttribute($attributeCode);
-            if (!is_object($attribute)) {
+	    if ($attribute === false) {
                 continue;
-//                Mage::throwException('Attribute ' . $attributeCode . ' not found.');
             }
-            if ($attribute->getSourceModel() != 'eav/entity_attribute_source_table') {
+	    if (!($attribute->getSource() instanceof Mage_Eav_Model_Entity_Attribute_Source_Abstract)) {
                 Mage::throwException('Attribute ' . $attributeCode . ' is no dropdown attribute.');
             }
             $attributes[$attributeCode] = $attribute;
@@ -686,11 +685,10 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
 
             /** @var $attribute Mage_Eav_Model_Entity_Attribute */
             $attribute = Mage::getSingleton('catalog/product')->getResource()->getAttribute($attributeCode);
-            if (!is_object($attribute)) {
+	    if ($attribute === false) {
                 continue;
-//                Mage::throwException('Attribute ' . $attributeCode . ' not found.');
             }
-            if ($attribute->getBackendModel() != 'eav/entity_attribute_backend_array') {
+	    if (!($attribute->getBackend() instanceof Mage_Eav_Model_Entity_Attribute_Backend_Abstract)) {
                 Mage::throwException('Attribute ' . $attributeCode . ' is no multiselect attribute.');
             }
             $attributes[$attributeCode] = $attribute;


### PR DESCRIPTION
This PR contains two things:

1. Fix: Checking the instanceof the source model or backend model in
   methods setDropdownAttributes and setMultiselectAttributes instead of
   doing a string comparison which fails when you have custom models.
2. Fix: Add option IgnoreDuplicates to product importer	
3. An important bug fix when a string length is 0 and the array index -1 https://github.com/Zookal/AvS_FastSimpleImport/commit/097c8ace7500409cf9b45adc8e205da652b2fb8c

To point 1: We're using our own custom backend model which integrates the method signature of  eav/entity_attribute_source_table so therefore a string comparison is pretty bad 8-)

If anything is missing or strange please comment otherwise feel free to merge.