### PR TITLE
Add external images support

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import.php
@@ -30,8 +30,8 @@
  * @method string getUnsetEmptyFields()
  * @method AvS_FastSimpleImport_Model_Import setSymbolEmptyFields(string $value)
  * @method string getSymbolEmptyFields()
- * @method AvS_FastSimpleImport_Model_Import setUseExternalImages(boolean $value)
- * @method boolean getUseExternalImages()
+ * @method AvS_FastSimpleImport_Model_Import setDownloadExternalImages(boolean $value)
+ * @method boolean getDownloadExternalImages()
  */
 class AvS_FastSimpleImport_Model_Import extends Mage_ImportExport_Model_Import
 {
@@ -53,7 +53,7 @@ class AvS_FastSimpleImport_Model_Import extends Mage_ImportExport_Model_Import
         $this->setDisablePreprocessImageData(Mage::getStoreConfigFlag('fastsimpleimport/product/disable_preprocess_images'));
         $this->setUnsetEmptyFields(! Mage::getStoreConfigFlag('fastsimpleimport/general/clear_field_on_empty_string'));
         $this->setSymbolEmptyFields(Mage::getStoreConfig('fastsimpleimport/general/symbol_for_clear_field'));
-        $this->setUseExternalImages(Mage::getStoreConfigFlag('fastsimpleimport/product/use_external_images'));
+        $this->setDownloadExternalImages(Mage::getStoreConfigFlag('fastsimpleimport/product/download_external_images'));
     }
 
     /**
@@ -89,7 +89,7 @@ class AvS_FastSimpleImport_Model_Import extends Mage_ImportExport_Model_Import
         $entityAdapter->setDisablePreprocessImageData($this->getDisablePreprocessImageData());
         $entityAdapter->setUnsetEmptyFields($this->getUnsetEmptyFields());
         $entityAdapter->setSymbolEmptyFields($this->getSymbolEmptyFields());
-        $entityAdapter->setUseExternalImages($this->getUseExternalImages());
+        $entityAdapter->setDownloadExternalImages($this->getDownloadExternalImages());
         $this->setEntityAdapter($entityAdapter);
 
         $validationResult = $this->validateSource($data);
@@ -156,7 +156,7 @@ class AvS_FastSimpleImport_Model_Import extends Mage_ImportExport_Model_Import
         $entityAdapter->setDisablePreprocessImageData($this->getDisablePreprocessImageData());
         $entityAdapter->setUnsetEmptyFields($this->getUnsetEmptyFields());
         $entityAdapter->setSymbolEmptyFields($this->getSymbolEmptyFields());
-        $entityAdapter->setUseExternalImages($this->getUseExternalImages());
+        $entityAdapter->setDownloadExternalImages($this->getDownloadExternalImages());
         $this->setEntityAdapter($entityAdapter);
 
         $validationResult = $this->validateSource($data);

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import.php
@@ -156,6 +156,7 @@ class AvS_FastSimpleImport_Model_Import extends Mage_ImportExport_Model_Import
         $entityAdapter->setDisablePreprocessImageData($this->getDisablePreprocessImageData());
         $entityAdapter->setUnsetEmptyFields($this->getUnsetEmptyFields());
         $entityAdapter->setSymbolEmptyFields($this->getSymbolEmptyFields());
+        $entityAdapter->setUseExternalImages($this->getUseExternalImages());
         $this->setEntityAdapter($entityAdapter);
 
         $validationResult = $this->validateSource($data);

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import.php
@@ -30,6 +30,8 @@
  * @method string getUnsetEmptyFields()
  * @method AvS_FastSimpleImport_Model_Import setSymbolEmptyFields(string $value)
  * @method string getSymbolEmptyFields()
+ * @method AvS_FastSimpleImport_Model_Import setUseExternalImages(boolean $value)
+ * @method boolean getUseExternalImages()
  */
 class AvS_FastSimpleImport_Model_Import extends Mage_ImportExport_Model_Import
 {
@@ -51,6 +53,7 @@ class AvS_FastSimpleImport_Model_Import extends Mage_ImportExport_Model_Import
         $this->setDisablePreprocessImageData(Mage::getStoreConfigFlag('fastsimpleimport/product/disable_preprocess_images'));
         $this->setUnsetEmptyFields(! Mage::getStoreConfigFlag('fastsimpleimport/general/clear_field_on_empty_string'));
         $this->setSymbolEmptyFields(Mage::getStoreConfig('fastsimpleimport/general/symbol_for_clear_field'));
+        $this->setUseExternalImages(Mage::getStoreConfigFlag('fastsimpleimport/product/use_external_images'));
     }
 
     /**
@@ -86,6 +89,7 @@ class AvS_FastSimpleImport_Model_Import extends Mage_ImportExport_Model_Import
         $entityAdapter->setDisablePreprocessImageData($this->getDisablePreprocessImageData());
         $entityAdapter->setUnsetEmptyFields($this->getUnsetEmptyFields());
         $entityAdapter->setSymbolEmptyFields($this->getSymbolEmptyFields());
+        $entityAdapter->setUseExternalImages($this->getUseExternalImages());
         $this->setEntityAdapter($entityAdapter);
 
         $validationResult = $this->validateSource($data);

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -188,7 +188,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
             $this->_createAttributeOptions();
             $this->_preprocessImageData();
 
-            if (!$this->getAllowRenameFiles()) {
+            if (!$this->getAllowRenameFiles() && !$this->getUseExternalImages()) {
                 $this->_getUploader()->setAllowRenameFiles(false);
             }
         }

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -186,13 +186,10 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
     {
         if (!$this->_dataValidated) {
             $this->_createAttributeOptions();
+            $this->_preprocessImageData();
 
-            if (!$this->getUseExternalImages()) {
-                $this->_preprocessImageData();
-
-                if (!$this->getAllowRenameFiles()) {
-                    $this->_getUploader()->setAllowRenameFiles(false);
-                }
+            if (!$this->getAllowRenameFiles()) {
+                $this->_getUploader()->setAllowRenameFiles(false);
             }
         }
 
@@ -351,34 +348,37 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
                 if (!isset($rowData['_media_lable'])) {
                     $this->_getSource()->setValue('_media_lable', '');
                 }
-                if (strpos($rowData['_media_image'], 'http') === 0 && strpos($rowData['_media_image'], '://') !== false) {
 
-                    if (isset($rowData['_media_target_filename']) && $rowData['_media_target_filename']) {
-                        $targetFilename = $rowData['_media_target_filename'];
-                    } else {
-                        $targetFilename = basename(parse_url($rowData['_media_image'], PHP_URL_PATH));
-                    }
+                if (!$this->getUseExternalImages()) {
+                    if (strpos($rowData['_media_image'], 'http') === 0 && strpos($rowData['_media_image'], '://') !== false) {
 
-                    if (!is_file($this->_getUploader()->getTmpDir() . DS . $targetFilename)) {
-                        $this->_copyExternalImageFile($rowData['_media_image'], $targetFilename);
-                    }
-                    $this->_getSource()->setValue('_media_image', $targetFilename);
-
-                } else {
-
-                    if (isset($rowData['_media_target_filename']) && $rowData['_media_target_filename']) {
-                        $targetFilename = $rowData['_media_target_filename'];
+                        if (isset($rowData['_media_target_filename']) && $rowData['_media_target_filename']) {
+                            $targetFilename = $rowData['_media_target_filename'];
+                        } else {
+                            $targetFilename = basename(parse_url($rowData['_media_image'], PHP_URL_PATH));
+                        }
 
                         if (!is_file($this->_getUploader()->getTmpDir() . DS . $targetFilename)) {
-                            if (is_file($this->_getUploader()->getTmpDir() . DS . $rowData['_media_image'])) {
-                                copy($this->_getUploader()->getTmpDir() . DS . $rowData['_media_image'], $this->_getUploader()->getTmpDir() . DS . $targetFilename);
+                            $this->_copyExternalImageFile($rowData['_media_image'], $targetFilename);
+                        }
+                        $this->_getSource()->setValue('_media_image', $targetFilename);
+
+                    } else {
+
+                        if (isset($rowData['_media_target_filename']) && $rowData['_media_target_filename']) {
+                            $targetFilename = $rowData['_media_target_filename'];
+
+                            if (!is_file($this->_getUploader()->getTmpDir() . DS . $targetFilename)) {
+                                if (is_file($this->_getUploader()->getTmpDir() . DS . $rowData['_media_image'])) {
+                                    copy($this->_getUploader()->getTmpDir() . DS . $rowData['_media_image'], $this->_getUploader()->getTmpDir() . DS . $targetFilename);
+                                }
+                                $this->_getSource()->setValue('_media_image', $targetFilename);
                             }
-                            $this->_getSource()->setValue('_media_image', $targetFilename);
                         }
                     }
-                }
 
-                $this->_getSource()->unsetValue('_media_target_filename');
+                    $this->_getSource()->unsetValue('_media_target_filename');
+                }
             }
 
             $this->_getSource()->next();

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -58,7 +58,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
     protected $_symbolEmptyFields = false;
 
     /** @var null|bool */
-    protected $_useExternalImages = false;
+    protected $_downloadExternalImages = false;
 
     /**
      * Attributes with index (not label) value.
@@ -137,18 +137,18 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
     /**
      * @return boolean
      */
-    public function getUseExternalImages()
+    public function getDownloadExternalImages()
     {
-        return $this->_useExternalImages;
+        return $this->_downloadExternalImages;
     }
 
     /**
-     * @param boolean $useExternalImages
+     * @param boolean $downloadExternalImages
      * @return $this
      */
-    public function setUseExternalImages($useExternalImages)
+    public function setDownloadExternalImages($downloadExternalImages)
     {
-        $this->_useExternalImages = (boolean) $useExternalImages;
+        $this->_downloadExternalImages = (boolean) $downloadExternalImages;
         return $this;
     }
 
@@ -188,7 +188,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
             $this->_createAttributeOptions();
             $this->_preprocessImageData();
 
-            if (!$this->getAllowRenameFiles() && !$this->getUseExternalImages()) {
+            if (!$this->getAllowRenameFiles() && $this->getDownloadExternalImages()) {
                 $this->_getUploader()->setAllowRenameFiles(false);
             }
         }
@@ -349,7 +349,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
                     $this->_getSource()->setValue('_media_lable', '');
                 }
 
-                if (!$this->getUseExternalImages()) {
+                if ($this->getDownloadExternalImages()) {
                     if (strpos($rowData['_media_image'], 'http') === 0 && strpos($rowData['_media_image'], '://') !== false) {
 
                         if (isset($rowData['_media_target_filename']) && $rowData['_media_target_filename']) {
@@ -1051,7 +1051,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
                             ? 0 : $this->_websiteCodeToId[$rowData['_group_price_website']]
                     );
                 }
-                if (!$this->getUseExternalImages() && is_array($this->_imagesArrayKeys) && count($this->_imagesArrayKeys) > 0) {
+                if ($this->getDownloadExternalImages() && is_array($this->_imagesArrayKeys) && count($this->_imagesArrayKeys) > 0) {
                     foreach ($this->_imagesArrayKeys as $imageCol) {
                         if (!empty($rowData[$imageCol])) { // 5. Media gallery phase
                             if (!array_key_exists($rowData[$imageCol], $uploadedGalleryFiles)) {
@@ -1567,7 +1567,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
                     $mediaGalleryTableName,
                     $this->_connection->quoteInto('entity_id IN (?)', $productId)
                 );
-            } else if ($this->getUseExternalImages()) {
+            } else if (!$this->getDownloadExternalImages()) {
                 $insertedGalleryImgs = $this->_connection->fetchCol($this->_connection->select()
                     ->from($mediaGalleryTableName, 'value')
                     ->where('entity_id IN (?)', $productId)
@@ -1576,7 +1576,6 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
             }
 
             foreach ($mediaGalleryRows as $insertValue) {
-
                 if (!in_array($insertValue['value'], $insertedGalleryImgs)) {
                     $valueArr = array(
                         'attribute_id' => $insertValue['attribute_id'],

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -1531,4 +1531,93 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
         }
         return $attribute;
     }
+
+    /**
+     * Save product media gallery.
+     *
+     * @param array $mediaGalleryData
+     * @return Mage_ImportExport_Model_Import_Entity_Product
+     */
+    protected function _saveMediaGallery(array $mediaGalleryData)
+    {
+        if (empty($mediaGalleryData)) {
+            return $this;
+        }
+
+        static $mediaGalleryTableName = null;
+        static $mediaValueTableName = null;
+        static $productId = null;
+
+        if (!$mediaGalleryTableName) {
+            $mediaGalleryTableName = Mage::getModel('importexport/import_proxy_product_resource')
+                ->getTable('catalog/product_attribute_media_gallery');
+        }
+
+        if (!$mediaValueTableName) {
+            $mediaValueTableName = Mage::getModel('importexport/import_proxy_product_resource')
+                ->getTable('catalog/product_attribute_media_gallery_value');
+        }
+
+        foreach ($mediaGalleryData as $productSku => $mediaGalleryRows) {
+            $productId = $this->_newSku[$productSku]['entity_id'];
+            $insertedGalleryImgs = array();
+
+            if (Mage_ImportExport_Model_Import::BEHAVIOR_APPEND != $this->getBehavior()) {
+                $this->_connection->delete(
+                    $mediaGalleryTableName,
+                    $this->_connection->quoteInto('entity_id IN (?)', $productId)
+                );
+            } else if ($this->getUseExternalImages()) {
+                $insertedGalleryImgs = $this->_connection->fetchCol($this->_connection->select()
+                    ->from($mediaGalleryTableName, 'value')
+                    ->where('entity_id IN (?)', $productId)
+                    ->where('value LIKE ?', 'http://%')
+                );
+            }
+
+            foreach ($mediaGalleryRows as $insertValue) {
+
+                if (!in_array($insertValue['value'], $insertedGalleryImgs)) {
+                    $valueArr = array(
+                        'attribute_id' => $insertValue['attribute_id'],
+                        'entity_id'    => $productId,
+                        'value'        => $insertValue['value']
+                    );
+
+                    $this->_connection
+                        ->insertOnDuplicate($mediaGalleryTableName, $valueArr, array('entity_id'));
+
+                    $insertedGalleryImgs[] = $insertValue['value'];
+                }
+
+                $newMediaValues = $this->_connection->fetchPairs($this->_connection->select()
+                    ->from($mediaGalleryTableName, array('value', 'value_id'))
+                    ->where('entity_id IN (?)', $productId)
+                );
+
+                if (array_key_exists($insertValue['value'], $newMediaValues)) {
+                    $insertValue['value_id'] = $newMediaValues[$insertValue['value']];
+                }
+
+                $valueArr = array(
+                    'value_id' => $insertValue['value_id'],
+                    'store_id' => Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID,
+                    'label'    => $insertValue['label'],
+                    'position' => $insertValue['position'],
+                    'disabled' => $insertValue['disabled']
+                );
+
+                try {
+                    $this->_connection
+                        ->insertOnDuplicate($mediaValueTableName, $valueArr, array('value_id'));
+                } catch (Exception $e) {
+                    $this->_connection->delete(
+                        $mediaGalleryTableName, $this->_connection->quoteInto('value_id IN (?)', $newMediaValues)
+                    );
+                }
+            }
+        }
+
+        return $this;
+    }
 }

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -57,6 +57,9 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
     /** @var null|bool */
     protected $_symbolEmptyFields = false;
 
+    /** @var null|bool */
+    protected $_useExternalImages = false;
+
     /**
      * Attributes with index (not label) value.
      *
@@ -95,7 +98,6 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
         return $this->_allowRenameFiles;
     }
 
-
     /**
      * @return boolean
      */
@@ -103,7 +105,6 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
     {
         return $this->_disablePreprocessImageData;
     }
-
 
     /**
      * @param boolean $disablePreprocessImageData
@@ -115,7 +116,6 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
         return $this;
     }
 
-
     /**
      * @param boolean $value
      * @return $this
@@ -125,13 +125,30 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
         return $this;
     }
 
-
     /**
      * @param string $value
      * @return $this
      */
     public function setSymbolEmptyFields($value) {
         $this->_symbolEmptyFields = $value;
+        return $this;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function getUseExternalImages()
+    {
+        return $this->_useExternalImages;
+    }
+
+    /**
+     * @param boolean $useExternalImages
+     * @return $this
+     */
+    public function setUseExternalImages($useExternalImages)
+    {
+        $this->_useExternalImages = (boolean) $useExternalImages;
         return $this;
     }
 
@@ -169,10 +186,13 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
     {
         if (!$this->_dataValidated) {
             $this->_createAttributeOptions();
-            $this->_preprocessImageData();
 
-            if (!$this->getAllowRenameFiles()) {
-                $this->_getUploader()->setAllowRenameFiles(false);
+            if (!$this->getUseExternalImages()) {
+                $this->_preprocessImageData();
+
+                if (!$this->getAllowRenameFiles()) {
+                    $this->_getUploader()->setAllowRenameFiles(false);
+                }
             }
         }
 
@@ -1031,7 +1051,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
                             ? 0 : $this->_websiteCodeToId[$rowData['_group_price_website']]
                     );
                 }
-                if (is_array($this->_imagesArrayKeys)  && count($this->_imagesArrayKeys) > 0) {
+                if (!$this->getUseExternalImages() && is_array($this->_imagesArrayKeys) && count($this->_imagesArrayKeys) > 0) {
                     foreach ($this->_imagesArrayKeys as $imageCol) {
                         if (!empty($rowData[$imageCol])) { // 5. Media gallery phase
                             if (!array_key_exists($rowData[$imageCol], $uploadedGalleryFiles)) {

--- a/src/app/code/community/AvS/FastSimpleImport/etc/config.xml
+++ b/src/app/code/community/AvS/FastSimpleImport/etc/config.xml
@@ -75,7 +75,6 @@
                 <weight>0</weight>
                 <use_external_images>0</use_external_images>
                 <allow_rename_files>1</allow_rename_files>
-                <disable_preprocess_images>0</disable_preprocess_images>
             </product>
         </fastsimpleimport>
     </default>

--- a/src/app/code/community/AvS/FastSimpleImport/etc/config.xml
+++ b/src/app/code/community/AvS/FastSimpleImport/etc/config.xml
@@ -73,12 +73,11 @@
                 <status>1</status>
                 <visibility>4</visibility>
                 <weight>0</weight>
-                <use_external_images>0</use_external_images>
+                <download_external_images>1</download_external_images>
                 <allow_rename_files>1</allow_rename_files>
             </product>
         </fastsimpleimport>
     </default>
-
 
     <phpunit>
         <suite>

--- a/src/app/code/community/AvS/FastSimpleImport/etc/config.xml
+++ b/src/app/code/community/AvS/FastSimpleImport/etc/config.xml
@@ -70,10 +70,12 @@
                 <symbol_for_clear_field>###EMPTY###</symbol_for_clear_field>
             </general>
             <product>
-                <allow_rename_files>1</allow_rename_files>
                 <status>1</status>
                 <visibility>4</visibility>
                 <weight>0</weight>
+                <use_external_images>0</use_external_images>
+                <allow_rename_files>1</allow_rename_files>
+                <disable_preprocess_images>0</disable_preprocess_images>
             </product>
         </fastsimpleimport>
     </default>

--- a/src/app/code/community/AvS/FastSimpleImport/etc/system.xml
+++ b/src/app/code/community/AvS/FastSimpleImport/etc/system.xml
@@ -128,16 +128,6 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </multiselect_attributes>
-                        <allow_rename_files translate="label comment" module="fastsimpleimport">
-                            <label>Allow renaming of files</label>
-                            <comment>Image files get renamed if file with the same name exists</comment>
-                            <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>30</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>0</show_in_website>
-                            <show_in_store>0</show_in_store>
-                        </allow_rename_files>
                         <additional_image_attributes translate="label" module="fastsimpleimport">
                             <label>Additional Image Attributes</label>
                             <frontend_type>multiselect</frontend_type>
@@ -183,12 +173,34 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </weight>
+                        <use_external_images translate="label comment" module="fastsimpleimport">
+                            <label>Use external images</label>
+                            <comment>Images will not be downloaded, external URL's will be stored as they are.</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>170</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </use_external_images>
+                        <allow_rename_files translate="label comment" module="fastsimpleimport">
+                            <label>Allow renaming of files</label>
+                            <comment>Image files get renamed if file with the same name exists</comment>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <depends><use_external_images>0</use_external_images></depends>
+                            <sort_order>180</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </allow_rename_files>
                         <disable_preprocess_images translate="label comment" module="fastsimpleimport">
                             <label>Disable image preprocessing</label>
                             <comment>If the images are preprocessed it downloads images from external URL's, sets the image attribute ID and fills in missing data.</comment>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>170</sort_order>
+                            <depends><use_external_images>0</use_external_images></depends>
+                            <sort_order>190</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>

--- a/src/app/code/community/AvS/FastSimpleImport/etc/system.xml
+++ b/src/app/code/community/AvS/FastSimpleImport/etc/system.xml
@@ -199,7 +199,6 @@
                             <comment>If the images are preprocessed it downloads images from external URL's, sets the image attribute ID and fills in missing data.</comment>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <depends><use_external_images>0</use_external_images></depends>
                             <sort_order>190</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>

--- a/src/app/code/community/AvS/FastSimpleImport/etc/system.xml
+++ b/src/app/code/community/AvS/FastSimpleImport/etc/system.xml
@@ -173,22 +173,22 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </weight>
-                        <use_external_images translate="label comment" module="fastsimpleimport">
-                            <label>Use external images</label>
-                            <comment>Images will not be downloaded, external URL's will be stored as they are.</comment>
+                        <download_external_images translate="label comment" module="fastsimpleimport">
+                            <label>Download external images</label>
+                            <comment>If set to YES, images will not be downloaded and URLs will be stored as they are</comment>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
                             <sort_order>170</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
-                        </use_external_images>
+                        </download_external_images>
                         <allow_rename_files translate="label comment" module="fastsimpleimport">
                             <label>Allow renaming of files</label>
                             <comment>Image files get renamed if file with the same name exists</comment>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <depends><use_external_images>0</use_external_images></depends>
+                            <depends><download_external_images>1</download_external_images></depends>
                             <sort_order>180</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>0</show_in_website>


### PR DESCRIPTION
Hello,

This pull request add the support of external images.

When the flag is set to "Yes", images will not be downloaded and URLs will be inserted as they are :

``` php
$import = Mage::getModel('fastsimpleimport/import');

$import->setDownloadExternalImages(false)
       ->processProductImport($data);
```

``` php
array(
    array(
        'sku' => 'TESTSKU',
        '_media_image' => 'http://www.example.com/img_01.jpg',
        '_media_lable' => 'Base Image Label',
        '_media_position' => 1,
        'image' => 'http://www.example.com/img_01.jpg',
        'small_image' => 'http://www.example.com/img_02.jpg',
        'thumbnail' => 'http://www.example.com/img_03.jpg'
    ),
    array(
        'sku' => null,
        '_media_image' => 'http://www.example.com/img_02.jpg',
        '_media_lable' => 'Small Image Label',
        '_media_is_disabled' => 1
    ),
    array(
        'sku' => null,
        '_media_image' => 'http://www.example.com/img_03.jpg',
        '_media_lable' => 'Thumbnail Label',
        '_media_is_disabled' => 1
    )
)
```

This doesn't add external images support into Magento, a custom extension is needed.

Best regards,
Benoît LELEVÉ
www.exsellium.com
