### PR TITLE
Fix getAffectedEntityIds() for category (missing root)

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Category.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Category.php
@@ -933,10 +933,10 @@ class AvS_FastSimpleImport_Model_Import_Entity_Category extends Mage_ImportExpor
                 if (!$this->isRowAllowedToImport($rowData, $rowNum)) {
                     continue;
                 }
-                if (!isset($this->_newCategory[$rowData[self::COL_CATEGORY]]['entity_id'])) {
+                if (!isset($this->_newCategory[$rowData[self::COL_ROOT]][$rowData[self::COL_CATEGORY]]['entity_id'])) {
                     continue;
                 }
-                $categoryIds[] = $this->_newCategory[$rowData[self::COL_CATEGORY]]['entity_id'];
+                $categoryIds[] = $this->_newCategory[$rowData[self::COL_ROOT]][$rowData[self::COL_CATEGORY]]['entity_id'];
             }
         }
         return $categoryIds;


### PR DESCRIPTION
Hello,

This pull request fix the method getAffectedEntityIds() of the class AvS_FastSimpleImport_Model_Import_Entity_Category (missing root category key).

Best regards,
Benoît LELEVE
www.exsellium.com