### PR TITLE
Fix issue #154 using code from Category/Api.php

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Category.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Category.php
@@ -94,6 +94,15 @@ class AvS_FastSimpleImport_Model_Import_Entity_Category extends Mage_ImportExpor
         'available_sort_by'
     );
 
+    /**
+     * Attributes that 'use_config' is a valid option for.
+     *
+     * @var array
+     */
+    protected $_canUseConfigAttributes = array(
+        'default_sort_by',
+        'available_sort_by'
+    );
 
     /**
      * Validation failure message template definitions
@@ -911,7 +920,10 @@ class AvS_FastSimpleImport_Model_Import_Entity_Category extends Mage_ImportExpor
             foreach ($this->_attributes as $attrCode => $attrParams) {
                 if (isset($rowData[$attrCode]) && strlen($rowData[$attrCode])) {
                     $this->isAttributeValid($attrCode, $attrParams, $rowData, $rowNum);
-                } elseif ($attrParams['is_required'] && !isset($this->_categoriesWithRoots[$root][$category])) {
+                } elseif ($attrParams['is_required'] &&
+                    !isset($this->_categoriesWithRoots[$root][$category]) &&
+                    !in_array($attrCode, $rowData['use_post_data_config'])
+                ) {
                     $this->addRowError(self::ERROR_VALUE_IS_REQUIRED, $rowNum, $attrCode);
                 }
             }
@@ -1178,6 +1190,14 @@ class AvS_FastSimpleImport_Model_Import_Entity_Category extends Mage_ImportExpor
                 }
             }
         }
+        $useConfig = array();
+        foreach ($this->_canUseConfigAttributes as $attrCode) {
+            if (array_key_exists($attrCode, $rowData) && 'use_config' == $rowData[$attrCode]) {
+                $rowData[$attrCode] = NULL;
+                $useConfig[]= $attrCode;
+            }
+        }
+        $rowData['use_post_data_config'] = $useConfig;
     }
 
     /**


### PR DESCRIPTION
In the function create in
`app/code/core/Mage/Catalog/Model/Category/Api.php` there’s some code
that unsets the values of the sortby attributes (default_sort_by and
available_sort_by) that are set to `use_config` and sets a new value,
`use_post_data_config`, with the unset attribute codes, then
app/code/core/Mage/Catalog/Model/Category/Attribute/Backend/Sortby.php
in it’s `validate` method checks for `use_post_data_config` and
overrides the `isRequired` check for it