### PR TITLE
Add rewrite for import entity product, otherwise CSV import is not working

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/etc/config.xml
+++ b/src/app/code/community/AvS/FastSimpleImport/etc/config.xml
@@ -19,6 +19,11 @@
             <fastsimpleimport>
                 <class>AvS_FastSimpleImport_Model</class>
             </fastsimpleimport>
+            <importexport>
+                <rewrite>
+                    <import_entity_product>AvS_FastSimpleImport_Model_Import_Entity_Product</import_entity_product>
+                </rewrite>
+            </importexport>
         </models>
 
         <helpers>


### PR DESCRIPTION
If the model is not rewritten there will be an error during csv import in 
src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product/Type/Configurable.php on line 166