### PR TITLE
added baseprice attributes to $_indexValueAttributes array

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -69,7 +69,9 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
         'enable_googlecheckout',
         'gift_message_available',
         'custom_design',
-        'country_of_manufacture'
+        'country_of_manufacture',
+        'base_price_unit',
+        'base_price_base_unit',
     );
 
     /**


### PR DESCRIPTION
added baseprice attributes to $_indexValueAttributes array so we can import those attributes like this:

'base_price_unit'. Possible options are: kg, lbs, g, mg, l, ml, m, sqm, in, cm, mm, pcs, rw.
'base_price_base_unit'. Possible options are: kg, lbs, g, mg, l, ml, m, sqm, in, cm, mm, pcs, rw.