### PR TITLE
[FIX] avoid syntax error, unexpected '['

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Category.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Category.php
@@ -1291,14 +1291,14 @@ class AvS_FastSimpleImport_Model_Import_Entity_Category extends Mage_ImportExpor
     protected function _initOnTabAttributes()
     {
         if (Mage::helper('core')->isModuleEnabled('OnTap_Merchandiser')) {
-            $this->_particularAttributes = array_merge($this->_particularAttributes, [
+            $this->_particularAttributes = array_merge($this->_particularAttributes, array( 
                 '_ontap_heroproducts',
                 '_ontap_attribute',
                 '_ontap_attribute_value',
                 '_ontap_attribute_logic',
                 '_ontap_ruled_only',
                 '_ontap_automatic_sort'
-            ]);
+            ));
         }
         return $this;
     }
@@ -1319,7 +1319,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Category extends Mage_ImportExpor
 
         $entityTable = Mage::getSingleton('core/resource')->getTableName('merchandiser_category_values');
         $categoryId = null;
-        $attributeIdsByCode = [];
+        $attributeIdsByCode = array();
 
         while ($bunch = $this->_dataSourceModel->getNextBunch()) {
             $onTapData = array();
@@ -1335,14 +1335,14 @@ class AvS_FastSimpleImport_Model_Import_Entity_Category extends Mage_ImportExpor
                     $category = $this->getEntityByCategory($rowData[self::COL_ROOT], $rowData[self::COL_CATEGORY]);
                     $categoryId = (int) $category['entity_id'];
 
-                    $onTapData[$categoryId] = [
+                    $onTapData[$categoryId] = array(
                         'category_id' => $categoryId,
                         'heroproducts'     => '',
                         'attribute_codes'  => '',
                         'smart_attributes' => '',
                         'ruled_only'       => '',
                         'automatic_sort'   => ''
-                    ];
+                    );
                 }
 
                 //we have a non-SCOPE_DEFAULT row, we check if it has a stock_id, if not, skip it.
@@ -1356,21 +1356,21 @@ class AvS_FastSimpleImport_Model_Import_Entity_Category extends Mage_ImportExpor
                 }
 
                 //get the _ontab_* smart attribute values and map them to the new keys that are present in the database.
-                $smartAttributes = array_intersect_key($rowData, [
+                $smartAttributes = array_intersect_key($rowData, array(
                     '_ontap_attribute' => '',
                     '_ontap_attribute_value' => '',
                     '_ontap_attribute_logic' => '',
-                ]);
+                ));
 
                 //only add if we've found data
                 //todo check if we've got all values, there should be three, else it will throw an error here.
                 if ($smartAttributes) {
                     if (! isset($onTapData[$categoryId]['attribute_codes'])) {
-                        $onTapData[$categoryId]['attribute_codes'] = [];
-                        $onTapData[$categoryId]['smart_attributes'] = [];
+                        $onTapData[$categoryId]['attribute_codes'] = array();
+                        $onTapData[$categoryId]['smart_attributes'] = array();
                     }
 
-                    $smartAttributes = array_combine(['attribute', 'value', 'link'],  $smartAttributes);
+                    $smartAttributes = array_combine(array('attribute', 'value', 'link'),  $smartAttributes);
 
                     if (! isset($attributeIdsByCode[$smartAttributes['attribute']])) {
                         $attributeIdsByCode[$smartAttributes['attribute']] =
@@ -1389,7 +1389,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Category extends Mage_ImportExpor
 
                 if (isset($rowData['_ontap_heroproducts'])) {
                     if (! isset($onTapData[$categoryId]['heroproducts'])) {
-                        $onTapData[$categoryId]['heroproducts'] = [];
+                        $onTapData[$categoryId]['heroproducts'] = array();
                     }
                     $onTapData[$categoryId]['heroproducts'][] = $rowData['_ontap_heroproducts'];
                 }


### PR DESCRIPTION
On older PHP Version like 5.3.10 using [] instead of array() throws "Parse error: syntax error, unexpected '['" which prevents run.

See: https://wiki.php.net/rfc/functionarraydereferencing