### PR TITLE
Fixes possible security issues with excel formula injection in csv data, see APPSEC-1110 (SUPEE-7405).

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Category.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Category.php
@@ -1163,11 +1163,12 @@ class AvS_FastSimpleImport_Model_Import_Entity_Category extends Mage_ImportExpor
     protected function _getProcessedCategoryIds()
     {
         $categoryIds = array();
-        $source = $this->getSource();
+        $coreHelper = Mage::helper("core");
+        $source = $this->_getSource();
 
         $source->rewind();
         while ($source->valid()) {
-            $current = $source->current();
+            $current = $coreHelper->unEscapeCSVData($source->current());
             if (isset($this->_newCategory[$current[self::COL_ROOT]][$current[self::COL_CATEGORY]])) {
                 $categoryIds[] = $this->_newCategory[$current[self::COL_ROOT]][$current[self::COL_CATEGORY]];
             } elseif (isset($this->_categoriesWithRoots[$current[self::COL_ROOT]][$current[self::COL_CATEGORY]])) {
@@ -1210,6 +1211,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Category extends Mage_ImportExpor
      */
     protected function _saveValidatedBunches()
     {
+        $coreHelper = Mage::helper("core");
         $source = $this->_getSource();
         $bunchRows = array();
         $startNewBunch = false;
@@ -1234,7 +1236,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Category extends Mage_ImportExpor
                 if ($this->_errorsCount >= $this->_errorsLimit) { // errors limit check
                     return $this;
                 }
-                $rowData = $source->current();
+                $rowData = $coreHelper->unEscapeCSVData($source->current());
 
                 $this->_processedRowsCount++;
 
@@ -1291,7 +1293,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Category extends Mage_ImportExpor
     protected function _initOnTabAttributes()
     {
         if (Mage::helper('core')->isModuleEnabled('OnTap_Merchandiser')) {
-            $this->_particularAttributes = array_merge($this->_particularAttributes, array( 
+            $this->_particularAttributes = array_merge($this->_particularAttributes, array(
                 '_ontap_heroproducts',
                 '_ontap_attribute',
                 '_ontap_attribute_value',

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -225,10 +225,13 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
             return;
         }
 
-        $this->_getSource()->rewind();
-        while ($this->_getSource()->valid()) {
+        $coreHelper = Mage::helper("core");
+        $source = $this->_getSource();
 
-            $rowData = $this->_getSource()->current();
+        $source->rewind();
+        while ($source->valid()) {
+
+            $rowData = $coreHelper->unEscapeCSVData($source->current());
             $this->_filterRowData($rowData);
             foreach ($this->getDropdownAttributes() as $attribute) {
 
@@ -245,7 +248,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
                 }
             }
 
-            $this->_getSource()->next();
+            $source->next();
         }
     }
 
@@ -258,10 +261,13 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
             return;
         }
 
-        $this->_getSource()->rewind();
-        while ($this->_getSource()->valid()) {
+        $coreHelper = Mage::helper("core");
+        $source = $this->_getSource();
 
-            $rowData = $this->_getSource()->current();
+        $source->rewind();
+        while ($source->valid()) {
+
+            $rowData = $coreHelper->unEscapeCSVData($source->current());
             $this->_filterRowData($rowData);
             foreach ($this->getMultiselectAttributes() as $attribute) {
 
@@ -278,7 +284,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
                 }
             }
 
-            $this->_getSource()->next();
+            $source->next();
         }
     }
 
@@ -340,24 +346,26 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
             return;
         }
 
+        $coreHelper = Mage::helper("core");
+        $source = $this->_getSource();
         $mediaAttributeId = Mage::getSingleton('catalog/product')->getResource()->getAttribute('media_gallery')->getAttributeId();
 
-        $this->_getSource()->rewind();
-        while ($this->_getSource()->valid()) {
+        $source->rewind();
+        while ($source->valid()) {
 
-            $rowData = $this->_getSource()->current();
+            $rowData = $coreHelper->unEscapeCSVData($source->current());
             if (isset($rowData['_media_image'])) {
                 if (!isset($rowData['_media_attribute_id']) || !$rowData['_media_attribute_id']) {
-                    $this->_getSource()->setValue('_media_attribute_id', $mediaAttributeId);
+                    $source->setValue('_media_attribute_id', $mediaAttributeId);
                 }
                 if (!isset($rowData['_media_is_disabled']) || !$rowData['_media_is_disabled']) {
-                    $this->_getSource()->setValue('_media_is_disabled', 0);
+                    $source->setValue('_media_is_disabled', 0);
                 }
                 if (!isset($rowData['_media_position']) || !$rowData['_media_position']) {
-                    $this->_getSource()->setValue('_media_position', 0);
+                    $source->setValue('_media_position', 0);
                 }
                 if (!isset($rowData['_media_lable'])) {
-                    $this->_getSource()->setValue('_media_lable', '');
+                    $source->setValue('_media_lable', '');
                 }
                 if (strpos($rowData['_media_image'], 'http') === 0 && strpos($rowData['_media_image'], '://') !== false) {
 
@@ -370,7 +378,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
                     if (!is_file($this->_getUploader()->getTmpDir() . DS . $targetFilename)) {
                         $this->_copyExternalImageFile($rowData['_media_image'], $targetFilename);
                     }
-                    $this->_getSource()->setValue('_media_image', $targetFilename);
+                    $source->setValue('_media_image', $targetFilename);
 
                 } else {
 
@@ -381,15 +389,15 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
                             if (is_file($this->_getUploader()->getTmpDir() . DS . $rowData['_media_image'])) {
                                 copy($this->_getUploader()->getTmpDir() . DS . $rowData['_media_image'], $this->_getUploader()->getTmpDir() . DS . $targetFilename);
                             }
-                            $this->_getSource()->setValue('_media_image', $targetFilename);
+                            $source->setValue('_media_image', $targetFilename);
                         }
                     }
                 }
 
-                $this->_getSource()->unsetValue('_media_target_filename');
+                $source->unsetValue('_media_target_filename');
             }
 
-            $this->_getSource()->next();
+            $source->next();
         }
     }
 
@@ -492,11 +500,12 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
     protected function _getProcessedProductSkus()
     {
         $skus = array();
-        $source = $this->getSource();
+        $coreHelper = Mage::helper("core");
+        $source = $this->_getSource();
 
         $source->rewind();
         while ($source->valid()) {
-            $current = $source->current();
+            $current = $coreHelper->unEscapeCSVData($source->current());
             $key = $source->key();
 
             if (! empty($current[self::COL_SKU]) && $this->_validatedRows[$key]) {
@@ -601,11 +610,12 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
     protected function _getProcessedProductIds()
     {
         $productIds = array();
-        $source = $this->getSource();
+        $coreHelper = Mage::helper("core");
+        $source = $this->_getSource();
 
         $source->rewind();
         while ($source->valid()) {
-            $current = $source->current();
+            $current = $coreHelper->unEscapeCSVData($source->current());
             if (! empty($current['sku']) && isset($this->_oldSku[$current[self::COL_SKU]])) {
                 $productIds[] = $this->_oldSku[$current[self::COL_SKU]]['entity_id'];
             } elseif (! empty($current['sku']) && isset($this->_newSku[$current[self::COL_SKU]])) {
@@ -1446,6 +1456,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
      */
     protected function _saveValidatedBunches()
     {
+        $coreHelper = Mage::helper("core");
         $source = $this->_getSource();
         $bunchRows = array();
         $startNewBunch = false;
@@ -1470,7 +1481,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
                 if ($this->_errorsCount >= $this->_errorsLimit) { // errors limit check
                     return $this;
                 }
-                $rowData = $source->current();
+                $rowData = $coreHelper->unEscapeCSVData($source->current());
 
                 $this->_processedRowsCount++;
 


### PR DESCRIPTION
See https://github.com/avstudnitz/AvS_FastSimpleImport/issues/277

Unescapes the csv data everywhere I could find a call to $source->current(). This was recently introduced in security patch SUPEE-7405:
https://github.com/brentwpeterson/magento-patches/blob/master/CE1.9-EE1.14/PATCH_SUPEE-7405_CE_1.9.2.2_v1-2016-01-20-04-35-33.sh#L1697

Also replaced all `$this->getSource()` calls to `this->_getSource()`, so it is consistent all over the codebase (the only difference between those two methods is the public vs protected visibility & the message in the exception).

Also always use a `$source` variable, instead of multiple `this->_getSource()` calls in the same method.

Note: I have **not** tested this. So please review & test before merging!
