### PR TITLE
Hotfix external image 404

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,7 +7,7 @@ Wrapper for Magento ImportExport functionality which imports data from arrays
 
 Facts
 -----
-- version: 0.6.4
+- version: 0.7.0
 - extension key: AvS_FastSimpleImport
 - extension on Magento Connect: n/a
 - Magento Connect 1.0 extension key: n/a
@@ -22,14 +22,14 @@ Description
 This module allows to import from arrays and thus using any import source, while the Magento module only imports from files. 
 ImportExport exists since Magento 1.5 CE / 1.10 EE, image import since 1.6 CE / 1.11 EE. Thus, this module needs at least 
 one of those versions.
-ImportExport has a special import format. See [specifications](http://www.integer-net.de/download/ImportExport_EN.pdf) about the expected format.
+ImportExport has a special import format. See [specifications](https://www.integer-net.com/importing-products-with-the-import-export-interface/) about the expected format.
 
 Main Features:
 
 - Fast Import using the built in Magento module ImportExport
 - Partial Indexing of only the imported products available
 - Unit tests for many test cases included
-- Importing of additional entities: Categories, Category-Product relations, attribute options (coming soon)
+- Importing of additional entities: Categories, Category-Product relations
 - Improved error messages stating which values are expected instead of a given value
 
 Please see our [**documentation**](http://avstudnitz.github.io/AvS_FastSimpleImport/) for a full list of features.
@@ -49,7 +49,7 @@ Installation Instructions
 2. If you are using the Enterprise Edition then add ```<Enterprise_ImportExport/>``` to the ```<depends>``` node directly after ```<Mage_ImportExport/>```
 3. Clear the cache, logout from the admin panel and then login again.
 4. Read the [documentation](http://avstudnitz.github.io/AvS_FastSimpleImport/)
-5. Configure the extension under System -> Configuration -> Services -> FastSimpleImport.
+5. Configure the extension at `System -> Configuration -> Services -> FastSimpleImport`.
 
 Uninstallation
 --------------

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import.php
@@ -51,7 +51,7 @@ class AvS_FastSimpleImport_Model_Import extends Mage_ImportExport_Model_Import
         $this->setAllowRenameFiles(Mage::getStoreConfigFlag('fastsimpleimport/product/allow_rename_files'));
         $this->setImageAttributes(array_filter(explode(',', Mage::getStoreConfig('fastsimpleimport/product/additional_image_attributes'))));
         $this->setDisablePreprocessImageData(Mage::getStoreConfigFlag('fastsimpleimport/product/disable_preprocess_images'));
-        $this->setUnsetEmptyFields(! Mage::getStoreConfigFlag('fastsimpleimport/general/clear_field_on_empty_string'));
+        $this->setUnsetEmptyFields(Mage::getStoreConfigFlag('fastsimpleimport/general/clear_field_on_empty_string'));
         $this->setSymbolEmptyFields(Mage::getStoreConfig('fastsimpleimport/general/symbol_for_clear_field'));
         $this->setSymbolIgnoreFields(Mage::getStoreConfig('fastsimpleimport/general/symbol_for_ignore_field'));
     }

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -659,7 +659,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
                     $urlModel->refreshProductRewrite($productId);
                 }
             }
-            if (Mage::helper('catalog/category_flat')->isEnabled()) {
+            if (Mage::helper('catalog/product_flat')->isEnabled()) {
                 Mage::dispatchEvent('fastsimpleimport_reindex_products_before_flat', array('entity_id' => &$entityIds));
                 Mage::getSingleton('catalog/product_flat_indexer')->saveProduct($entityIds);
             }

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -198,7 +198,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
      * @param string $value
      * @return $this
      */
-    public function setSymbolIgnoreFields($value) 
+    public function setSymbolIgnoreFields($value)
     {
         $this->_symbolIgnoreFields = $value;
         return $this;
@@ -497,7 +497,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
                 throw new Exception('Got 404 while fetching image from url ' . $url);
             }
         } catch (Exception $e) {
-            Mage::throwException('Download of file ' . $url . ' failed: ' . $e->getMessage());
+            Mage::logException($e);
         }
     }
 

--- a/src/app/code/community/AvS/FastSimpleImport/etc/config.xml
+++ b/src/app/code/community/AvS/FastSimpleImport/etc/config.xml
@@ -10,7 +10,7 @@
 <config>
     <modules>
         <AvS_FastSimpleImport>
-            <version>0.6.4</version>
+            <version>0.7.0</version>
         </AvS_FastSimpleImport>
     </modules>
 

--- a/src/app/code/community/AvS/FastSimpleImport/etc/config.xml
+++ b/src/app/code/community/AvS/FastSimpleImport/etc/config.xml
@@ -19,6 +19,11 @@
             <fastsimpleimport>
                 <class>AvS_FastSimpleImport_Model</class>
             </fastsimpleimport>
+            <importexport>
+                <rewrite>
+                    <import_entity_product>AvS_FastSimpleImport_Model_Import_Entity_Product</import_entity_product>
+                </rewrite>
+            </importexport>
         </models>
 
         <helpers>


### PR DESCRIPTION
When the import process encounters a 404 while downloading an image, the whole import process is halted by throwing an exception.

Yes, I know that this is an error with the import data and the image should really be there. But let's face it, most of the times we don't have control over the other end.

Maybe this should be dependant upon the continueAfterErrors setting and only fail, if the setting is `false`.