### PR TITLE
External image yields 404 - Exception halts import

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -198,7 +198,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
      * @param string $value
      * @return $this
      */
-    public function setSymbolIgnoreFields($value) 
+    public function setSymbolIgnoreFields($value)
     {
         $this->_symbolIgnoreFields = $value;
         return $this;
@@ -497,7 +497,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
                 throw new Exception('Got 404 while fetching image from url ' . $url);
             }
         } catch (Exception $e) {
-            Mage::throwException('Download of file ' . $url . ' failed: ' . $e->getMessage());
+            Mage::logException($e);
         }
     }
 


### PR DESCRIPTION
When the import process encounters a 404 while downloading an image, the whole import process is halted by throwing an exception.

Yes, I know that this is an error with the import data and the image should really be there. But let's face it, most of the times we don't have control over the other end.

Maybe this should be dependant upon the continueAfterErrors setting and only fail, if the setting is `false`.
