### PR TITLE
Fixed Issue That Attribute Options Were Created Twice

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -377,7 +377,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
 
         $attribute->save();
 
-        $this->_attributeOptions[$attribute->getAttributeCode()][] = $optionLabel;
+        $this->_attributeOptions[$attribute->getAttributeCode()][] = Mage::helper('fastsimpleimport')->strtolower($optionLabel);
         $this->_initTypeModels();
     }
 


### PR DESCRIPTION
This PR fixes an issue introduced with #289. We lowercase the attribute option labels, so that they are case-insensitive. Newly created attribute options created by the method `_createAttributeOption` were not lowercased, which caused this option to be created once again.

@jamescowie maybe you can also have a look at this PR and merge it, because you already cared about the other PR and know the topic now.