### PR TITLE
[FIX] delete old product attribute if import is not append mode

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -1041,6 +1041,15 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
                         }
                     }
                 }
+
+                if (Mage_ImportExport_Model_Import::BEHAVIOR_APPEND != $this->getBehavior()) {
+                    $where = $this->_connection->quoteInto('entity_id = ?', $productId) .
+                        $this->_connection->quoteInto(' AND entity_type_id = ?', $this->_entityTypeId);
+
+                    $this->_connection->delete(
+                        $tableName, $where
+                    );
+                }
             }
 
             if (count($tableData)) {

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -1040,15 +1040,22 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
                             ));
                         }
                     }
-                }
 
-                if (Mage_ImportExport_Model_Import::BEHAVIOR_APPEND != $this->getBehavior()) {
-                    $where = $this->_connection->quoteInto('entity_id = ?', $productId) .
-                        $this->_connection->quoteInto(' AND entity_type_id = ?', $this->_entityTypeId);
+                    if (Mage_ImportExport_Model_Import::BEHAVIOR_APPEND != $this->getBehavior()) {
+                        /**
+                         * If the store based values are not provided for a particular store,
+                         * we default to the default scope values.
+                         * In this case, remove all the existing store based values stored in the table.
+                         **/
+                        $where = $this->_connection->quoteInto('store_id NOT IN (?)', array_keys($storeValues)) .
+                            $this->_connection->quoteInto(' AND attribute_id = ?', $attributeId) .
+                            $this->_connection->quoteInto(' AND entity_id = ?', $productId) .
+                            $this->_connection->quoteInto(' AND entity_type_id = ?', $this->_entityTypeId);
 
-                    $this->_connection->delete(
-                        $tableName, $where
-                    );
+                        $this->_connection->delete(
+                            $tableName, $where
+                        );
+                    }
                 }
             }
 


### PR DESCRIPTION
Magento fixed this on its own after this method was copied to AVS: https://github.com/OpenMage/magento-mirror/blame/magento-1.9/app/code/core/Mage/ImportExport/Model/Import/Entity/Product.php#L1191

Replace the whole method with the core ones would allways force replace mode on attribute level. So I moved the deletion further out of the loops to reduce number of queries and run it only if not in append mode. This fixes #315
