### PR TITLE
SR-850 catch exception to ensure re-enable of config flag

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import.php
@@ -122,21 +122,31 @@ class AvS_FastSimpleImport_Model_Import extends Mage_ImportExport_Model_Import
                         
                     case AvS_FastSimpleImport_Model_System_Config_Source_Product_IndexingMode::INDEXING_MODE_ASYNC:
 
-                        $this->importSource();
+                        try {
+                            $this->importSource();
 
-                        // disable AsyncIndex for the time of creating new index events in order to avoid locked table
-                        $autoIndexOriginalConfigValue = Mage::getStoreConfigFlag('system/asyncindex/auto_index');
-                        if ($autoIndexOriginalConfigValue) {
-                            Mage::getResourceModel('core/setup', 'core_setup')->setConfigData('system/asyncindex/auto_index', 0);
-                            Mage::app()->getCacheInstance()->cleanType('config');
-                        }
+                            // disable AsyncIndex for the time of creating new index events in order to avoid locked table
+                            $autoIndexOriginalConfigValue = Mage::getStoreConfigFlag('system/asyncindex/auto_index');
+                            if ($autoIndexOriginalConfigValue) {
+                                Mage::getResourceModel('core/setup', 'core_setup')->setConfigData('system/asyncindex/auto_index', 0);
+                                Mage::app()->getCacheInstance()->cleanType('config');
+                            }
 
-                        $this->_createIndexEvents();
+                            $this->_createIndexEvents();
 
-                        // re-enable AsyncIndex
-                        if ($autoIndexOriginalConfigValue) {
-                            Mage::getResourceModel('core/setup', 'core_setup')->setConfigData('system/asyncindex/auto_index', 1);
-                            Mage::app()->getCacheInstance()->cleanType('config');
+                            // re-enable AsyncIndex
+                            if ($autoIndexOriginalConfigValue) {
+                                Mage::getResourceModel('core/setup', 'core_setup')->setConfigData('system/asyncindex/auto_index', 1);
+                                Mage::app()->getCacheInstance()->cleanType('config');
+                            }
+                        } catch (Exception $e) {
+                            Mage::logException($e);
+                            // re-enable AsyncIndex
+                            $autoIndexOriginalConfigValue = Mage::getStoreConfigFlag('system/asyncindex/auto_index');
+                            if ($autoIndexOriginalConfigValue) {
+                                Mage::getResourceModel('core/setup', 'core_setup')->setConfigData('system/asyncindex/auto_index', 1);
+                                Mage::app()->getCacheInstance()->cleanType('config');
+                            }
                         }
                         break;
                     


### PR DESCRIPTION
SR-850 if the importer breaks at creating events or somewhere between, the store config value of AsyncIndex is disabled and therefore are not allowed to run by cronjob. This catch block ensures that it may run on error. If it breaks from php somewhere else or runtime is over for whatever reason, this fix wont stop that!
