### PR TITLE
Fix multiple store values when using nested arrays

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/NestedArrayAdapter.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/NestedArrayAdapter.php
@@ -58,7 +58,7 @@ class AvS_FastSimpleImport_Model_NestedArrayAdapter extends AvS_FastSimpleImport
 
                         $originalLineHasStoreScope = isset($line['_store']);
                         if ($originalLineHasStoreScope) {
-                            $newLines[$newLineNumber]['_store'] = $line['_store'];
+                            $newLines[$newLineNumber]['_store'] = $line['_store'][$newLineNumber];
                         }
                     }
                     $newLines[$newLineNumber++][$fieldName] = $singleFieldValue;


### PR DESCRIPTION
if you defined the "_store" nested array like this:

`'_store' => array('da','en')`

It would mistakenly set the resulting array like this, with both elements:

```
   [1] => Array
        (
..
            [_store] => Array
                (
                    [0] => da
                    [1] => en
                )
...
```
