### PR TITLE
Properly set rowNum during saveProducts

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -1061,6 +1061,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
         $productLimit   = null;
         $productsQty    = null;
         $rowSku         = null;
+        $rowNum 	= -1;
 
         while ($bunch = $this->_dataSourceModel->getNextBunch()) {
             $entityRowsIn = array();
@@ -1076,7 +1077,8 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
             $previousAttributeSet = null;
             $currentStoreId = Mage_Catalog_Model_Product::DEFAULT_STORE_ID;
 
-            foreach ($bunch as $rowNum => $rowData) {
+            foreach ($bunch as $rowData) {
+		$rowNum++;
                 $this->_filterRowData($rowData);
                 if (!$this->validateRow($rowData, $rowNum)) {
                     continue;


### PR DESCRIPTION
The rowNum was counted in each bunch freshly. This caused problems that validateData() was not called for subsequent bunches, causing additional problems. (see #330)