### PR TITLE
[BUG] Fix for default Enterprise Import tool

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/etc/config.xml
+++ b/src/app/code/community/AvS/FastSimpleImport/etc/config.xml
@@ -24,6 +24,11 @@
                     <import_entity_product>AvS_FastSimpleImport_Model_Import_Entity_Product</import_entity_product>
                 </rewrite>
             </importexport>
+            <enterprise_importexport>
+                <rewrite>
+                    <import_entity_product>AvS_FastSimpleImport_Model_Import_Entity_Product</import_entity_product>
+                </rewrite>
+            </enterprise_importexport>
         </models>
 
         <helpers>


### PR DESCRIPTION
The entity model is wrong if this module is running on a Magento Enterprise instance due to a missing rewrite.