### PR TITLE
Add multibyte aware strtolower to attribute-validation

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -939,7 +939,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
                     $valid = true; // Force validation in case of dry run with options of dropdown or multiselect which doesn't yet exist
                     break;
                 }
-                $valid = isset($attrParams['options'][strtolower($rowData[$attrCode])]);
+                $valid = isset($attrParams['options'][Mage::helper('fastsimpleimport')->strtolower($rowData[$attrCode])]);
                 $message = 'Possible options are: ' . implode(', ', array_keys($attrParams['options'])) . '. Your input: ' . $rowData[$attrCode];
                 break;
             case 'int':

--- a/test.php
+++ b/test.php
@@ -60,7 +60,7 @@ for ($i = 1; $i <= 10; $i++) {
         'is_in_stock' => 0,
         'enable_googlecheckout' => '1',
         'gift_message_available' => '0',
-        'url_key' => strtolower($randomString),
+        'url_key' => Mage::helper('fastsimpleimport')->strtolower($randomString),
     );
 }
 


### PR DESCRIPTION
If there were mb-chars (like Umlauts), the standard strtolower would
return a non-changed string. There was already a mb_strtolower wrapping
method done earlier and we just use that one from the helper.