### PR TITLE
Fix saving of stockItem data for multi-warehouse setups

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -1411,6 +1411,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
 
                 /** @var $stockItem Mage_CatalogInventory_Model_Stock_Item */
                 $stockItem = Mage::getModel('cataloginventory/stock_item');
+                $stockItem->setStockId($row['stock_id']);
                 $stockItem->loadByProduct($row['product_id']);
                 $existStockData = $stockItem->getData();
 


### PR DESCRIPTION
In one of our multi-warehouse shops, stockItems where stockId = 1 kept getting cleared, even though no stock-related fields were updated in the import.