### PR TITLE
Fix attribute option comparison by using multibyte strtolower

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -366,6 +366,36 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
         }
     }
 
+    public function getAttributeOptions(Mage_Eav_Model_Entity_Attribute_Abstract $attribute, $indexValAttrs = array())
+    {
+        $options = array();
+
+        if ($attribute->usesSource()) {
+            // merge global entity index value attributes
+            $indexValAttrs = array_merge($indexValAttrs, $this->_indexValueAttributes);
+
+            // should attribute has index (option value) instead of a label?
+            $index = in_array($attribute->getAttributeCode(), $indexValAttrs) ? 'value' : 'label';
+
+            // only default (admin) store values used
+            $attribute->setStoreId(Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID);
+
+            try {
+                foreach ($attribute->getSource()->getAllOptions(false) as $option) {
+                    $value = is_array($option['value']) ? $option['value'] : array($option);
+                    foreach ($value as $innerOption) {
+                        if (strlen($innerOption['value'])) { // skip ' -- Please Select -- ' option
+                            $options[Mage::helper('fastsimpleimport')->strtolower($innerOption[$index])] = $innerOption['value'];
+                        }
+                    }
+                }
+            } catch (Exception $e) {
+                // ignore exceptions connected with source models
+            }
+        }
+        return $options;
+    }
+
     /**
      * Get all options of a dropdown attribute
      *


### PR DESCRIPTION
Parent method is still used for comparing/validating attribute options, so need to override it and also make it use mb_strtolower