### PR TITLE
Refactored Downloadable Files Import

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -117,7 +117,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
     /**
      * Downloadable files uploader
      *
-     * @var Mage_ImportExport_Model_Import_Uploader
+     * @var AvS_FastSimpleImport_Model_Import_Uploader_Downloadable
      */
     protected $_downloadableUploader;
 

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Uploader/Downloadable.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Uploader/Downloadable.php
@@ -1,0 +1,18 @@
+<?php
+
+class AvS_FastSimpleImport_Model_Import_Uploader_Downloadable extends Mage_ImportExport_Model_Import_Uploader
+{
+
+    // set this to an empty array, so that all mime types and file extensions are allowed
+    protected $_allowedMimeTypes = array();
+
+    public function init()
+    {
+        parent::init();
+
+        // we want to support any file type, so remove the image specific validators
+        $this->removeValidateCallback('catalog_product_image');
+        $this->removeValidateCallback(Mage_Core_Model_File_Validator_Image::NAME);
+    }
+
+}


### PR DESCRIPTION
- imported downloaded files are now created via the standard uploader `Mage_ImportExport_Model_Import_Uploader`
- this ensures that these files are created in sub-folders like `/media/downloadable/files/links/f/i/file.pdf`
- this also ensures that these folders will be created if they do not exist yet