### PR TITLE
Use php's strtolower to fix preparing attributes with unicode values

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product/Type/Bundle.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product/Type/Bundle.php
@@ -268,7 +268,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product_Type_Bundle
                 if (isset($rowData[$attrCode]) && strlen($rowData[$attrCode])) {
                     $resultAttrs[$attrCode] =
                         ('select' == $attrParams['type'] || 'multiselect' == $attrParams['type'])
-                            ? $attrParams['options'][Mage::helper('fastsimpleimport')->strtolower($rowData[$attrCode])]
+                            ? $attrParams['options'][strtolower($rowData[$attrCode])]
                             : $rowData[$attrCode];
                 } elseif (array_key_exists($attrCode, $rowData)) {
                     $resultAttrs[$attrCode] = $rowData[$attrCode];

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product/Type/Configurable.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product/Type/Configurable.php
@@ -50,7 +50,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product_Type_Configurable
                 if (isset($rowData[$attrCode]) && strlen($rowData[$attrCode])) {
                     $resultAttrs[$attrCode] =
                         ('select' == $attrParams['type'] || 'multiselect' == $attrParams['type'])
-                            ? $attrParams['options'][Mage::helper('fastsimpleimport')->strtolower($rowData[$attrCode])]
+                            ? $attrParams['options'][strtolower($rowData[$attrCode])]
                             : $rowData[$attrCode];
                 } elseif (array_key_exists($attrCode, $rowData)) {
                     $resultAttrs[$attrCode] = $rowData[$attrCode];
@@ -245,7 +245,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product_Type_Configurable
                     );
                 }
                 if (isset($rowData['_super_attribute_option']) && strlen($rowData['_super_attribute_option'])) {
-                    $optionId = $attrParams['options'][Mage::helper('fastsimpleimport')->strtolower($rowData['_super_attribute_option'])];
+                    $optionId = $attrParams['options'][strtolower($rowData['_super_attribute_option'])];
 
                     if (!isset($productSuperData['used_attributes'][$attrParams['id']][$optionId])) {
                         $productSuperData['used_attributes'][$attrParams['id']][$optionId] = false;

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product/Type/Grouped.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product/Type/Grouped.php
@@ -30,7 +30,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product_Type_Grouped
                 if (isset($rowData[$attrCode]) && strlen($rowData[$attrCode])) {
                     $resultAttrs[$attrCode] =
                         ('select' == $attrParams['type'] || 'multiselect' == $attrParams['type'])
-                            ? $attrParams['options'][Mage::helper('fastsimpleimport')->strtolower($rowData[$attrCode])]
+                            ? $attrParams['options'][strtolower($rowData[$attrCode])]
                             : $rowData[$attrCode];
                 } elseif (array_key_exists($attrCode, $rowData)) {
                     $resultAttrs[$attrCode] = $rowData[$attrCode];

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product/Type/Simple.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product/Type/Simple.php
@@ -30,7 +30,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product_Type_Simple
                 if (isset($rowData[$attrCode]) && strlen($rowData[$attrCode])) {
                     $resultAttrs[$attrCode] =
                         ('select' == $attrParams['type'] || 'multiselect' == $attrParams['type'])
-                            ? $attrParams['options'][Mage::helper('fastsimpleimport')->strtolower($rowData[$attrCode])]
+                            ? $attrParams['options'][strtolower($rowData[$attrCode])]
                             : $rowData[$attrCode];
                 } elseif (array_key_exists($attrCode, $rowData)) {
                     $resultAttrs[$attrCode] = $rowData[$attrCode];


### PR DESCRIPTION
See function `getAttributeOptions` inside `Mage_ImportExport_Model_Import_Entity_Abstract`. `strtolower` is used there, generating keys with wrong encoding for unicode values of attributes. They don't match the keys of the own (and absolutely correct!) `strtolower` used before. Thus, attributes will be set to null because i.e. `straße` (generated by this plugin's strtolower) doesn't match `stra▒e` (generated by Magento). 