### PR TITLE
Fix get product attribute options (take only from default admin store)

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -398,6 +398,9 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
     {
         if (!isset($this->_attributeOptions[$attribute->getAttributeCode()])) {
             if (in_array($attribute->getFrontendInput(), array('select', 'multiselect'))) {
+                // only default (admin) store option values used
+                $attribute->setStoreId(Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID);
+
                 /** @var $attributeOptions Mage_Eav_Model_Entity_Attribute_Source_Table */
                 $attributeOptions = Mage::getModel('eav/entity_attribute_source_table');
                 $attributeOptions->setAttribute($attribute);


### PR DESCRIPTION
I faced with problem, that import duplicates product attribute options. The reason is, that some times (I don't know why 😞 ) it takes options not from default (admin) store, but from another store. In another store it can't find options, that are in default store, so as a result it creates new one option. 

The same part of code I found in Magento core import:
 [Mage_ImportExport_Model_Import_Entity_Abstract::getAttributeOptions()](https://github.com/bragento/magento-core/blob/1.9/app/code/core/Mage/ImportExport/Model/Import/Entity/Abstract.php#L370)