### PR TITLE
Catch errors during bunch encoding

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Resource/Import/Data.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Resource/Import/Data.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * ImportExport import data resource model
+ *
+ * @category   AvS
+ * @package    AvS_FastSimpleImport
+ * @author     Aoe Magento Team <team-magento@aoe.com>
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software Licence 3.0 (OSL-3.0)
+ * @link       https://github.com/AOEpeople/AvS_FastSimpleImport
+ */
+class AvS_FastSimpleImport_Model_Resource_Import_Data extends Mage_ImportExport_Model_Resource_Import_Data {
+
+    /**
+     * Save import rows bunch.
+     *
+     * @param string $entity
+     * @param string $behavior
+     * @param array $data
+     * @return int
+     * @throws Exception
+     */
+    public function saveBunch($entity, $behavior, array $data)
+    {
+        $json = Mage::helper('core')->jsonEncode($data);
+        if (false === $json) {
+            $error = json_last_error_msg();
+            throw new Exception(sprintf('Error encoding data for save: %s', $error));
+        }
+        return $this->_getWriteAdapter()->insert(
+            $this->getMainTable(),
+            array('behavior' => $behavior, 'entity' => $entity, 'data' => $json)
+        );
+    }
+}

--- a/src/app/code/community/AvS/FastSimpleImport/etc/config.xml
+++ b/src/app/code/community/AvS/FastSimpleImport/etc/config.xml
@@ -24,6 +24,11 @@
                     <import_entity_product>AvS_FastSimpleImport_Model_Import_Entity_Product</import_entity_product>
                 </rewrite>
             </importexport>
+            <importexport_resource>
+                <rewrite>
+                    <import_data>AvS_FastSimpleImport_Model_Resource_Import_Data</import_data>
+                </rewrite>
+            </importexport_resource>
         </models>
 
         <helpers>


### PR DESCRIPTION
If there is invalid data (e.g. NAN or INF) instead of failing to save the nuch to the database, an empty string is saved. This PR throws an Exception if json_encode fails.