### PR TITLE
Fix bug with negative "_super_attribute_price_corr" field value

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product/Type/Configurable.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product/Type/Configurable.php
@@ -352,4 +352,18 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product_Type_Configurable
         }
         return $this;
     }
+    
+    /**
+     * Fix bug with "_super_attribute_price_corr" field.
+     * When it has negative number (e.g. "-3"), the getEscapedCSVData() function
+     * adds whitespace (e.g. "-3" converts to " -3") and as a result, this function returns false.
+     * So I added trim() function, which removes whitespaces.
+     *
+     * @param string $value
+     * @return int
+     */
+    protected function _isPriceCorr($value)
+    {
+        return parent::_isPriceCorr(trim($value));
+    }
 }


### PR DESCRIPTION
This bug it related to configurable product import and appears, if all conditions are true:
- Configurable product has 2+ associated (simple) products (e.g. A and B)
- Product A has price 100 and is in stock
- Product B has price 50 and is out out stock

When runs configurable product builder (it creates configurable products), it do this things:
1) Calculates configurable product price, which should be minimal associated products price. So the minimal price of A and B product is 100. It skips product B, because it is out of stock.
2) Then it calculates "_super_attribute_price_corr" (it's a diff between configurable product price an associated product). For product A and it's "0" and for product B it's "-50".
3) Then AVS import creates .csv file for magento product import and inside of it is a function getEscapedCSVData() https://github.com/bragento/magento-core/blob/5dc6bfe423a2d8242c14d24c2d3482a8f0db3983/app/code/core/Mage/ImportExport/Model/Export/Adapter/Csv.php#L119 which adds whitespace for negative numbers. So getEscapedCSVData() changes our "-50" to " -50".  
4) Then runs Magento product import and inside it has function _isPriceCorr() https://github.com/bragento/magento-core/blob/5dc6bfe423a2d8242c14d24c2d3482a8f0db3983/app/code/core/Mage/ImportExport/Model/Import/Entity/Product/Type/Configurable.php#L208, which checks "_super_attribute_price_corr" field value. _isPriceCorr() function returns false, because "_super_attribute_price_corr" has whitespace.

As a result, we have "Super attribute price correction value is invalid" error and can't import configurable product. :(