### PR TITLE
Copied From Magento Product Entity to update url_keys as well

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -1210,6 +1210,22 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
                             ));
                         }
                     }
+			
+                    if ($attributeId == $this->_getUrlKeyAttributeId()) {
+                        /*
+                        If the store based values are not provided for a particular store,
+                        we default to the default scope values.
+                        In this case, remove all the existing store based values stored in the table.
+                        */
+                        $where = $this->_connection->quoteInto('store_id NOT IN (?)', array_keys($storeValues)) .
+                            $this->_connection->quoteInto(' AND attribute_id = ?', $attributeId) .
+                            $this->_connection->quoteInto(' AND entity_id = ?', $productId) .
+                            $this->_connection->quoteInto(' AND entity_type_id = ?', $this->_entityTypeId);
+
+                        $this->_connection->delete(
+                            $tableName, $where
+                        );
+                    }
 
                     if (Mage_ImportExport_Model_Import::BEHAVIOR_APPEND != $this->getBehavior()) {
                         /**


### PR DESCRIPTION
Without this fix, you cannot overwrite url_keys with product import. The lines are copied from Magento Core Files.