### PR TITLE
Fix duplicates when using additional image attributes

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -984,7 +984,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
         if (! is_array($attributeCodes)) {
             return;
         }
-        $this->_imagesArrayKeys = $this->_imageAttributes = array_merge($this->_imagesArrayKeys, $attributeCodes);
+        $this->_imagesArrayKeys = $this->_imageAttributes = array_unique(array_merge($this->_imagesArrayKeys, $attributeCodes));
     }
 
     /**


### PR DESCRIPTION
setImageAttributes() is called multiple times and will result in duplicate entries.