### PR TITLE
Only add comma for multiselect value when value is not null to prevent unnecessary commas in database.

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -1160,7 +1160,7 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
                 if ('multiselect' == $attribute->getFrontendInput()) {
                     if (!isset($attributes[$attrTable][$rowSku][$attrId][$storeId])) {
                         $attributes[$attrTable][$rowSku][$attrId][$storeId] = '';
-                    } else {
+                    } elseif ($attrValue !== null) {
                         $attributes[$attrTable][$rowSku][$attrId][$storeId] .= ',';
                     }
                     $attributes[$attrTable][$rowSku][$attrId][$storeId] .= $attrValue;


### PR DESCRIPTION
This is a behaviour that also exists on the core ImportExport (1.9.3.9) and creates unclean data on the catalog_product_entity_text table.

Reproduction:
- Magento 1.9.3.9
- Have multiple websites, for example base, de, fr, gb
- Have a multiselect attribute, for example sprachen with values Deutsch, Englisch, Französisch
- Import the following CSV via FastSimpleImport shell/import.php

> sku,_type,_attribute_set,_product_websites,name,description,price,status,visibility,tax_class_id,qty,sprachen,short_description
> testprodukt123,simple,Default,base,Tolles Produkt,Ein wirklich tolles Produkt,47.11,1,4,2,1337,Deutsch,Bla Blubb tolles Produkt
> ,,,de,,,,,,,,Französisch,
> ,,,gb,,,,,,,,,
> ,,,fr,,,,,,,,,

For each of the "null" values for the multiselect value, a comma will be added to the value that is written to database.

> mysql> select * from catalog_product_entity_text;
> +----------+----------------+--------------+----------+-----------+-----------------------------+
> | value_id | entity_type_id | attribute_id | store_id | entity_id | value                       |
> +----------+----------------+--------------+----------+-----------+-----------------------------+
> |        1 |              4 |           73 |        0 |         1 | Ein wirklich tolles Produkt |
> |        2 |              4 |           74 |        0 |         1 | Bla Blubb tolles Produkt    |
> |        5 |              4 |          133 |        0 |         1 | 3,5,,                       |
> +----------+----------------+--------------+----------+-----------+-----------------------------+
> 3 rows in set (0.00 sec)


The problem occured to us on a Magento 1.6.2 with FSI 0.8.2 using the array import (non-nested) and led to follow-up errors.