### PR TITLE
Fix for configs not imported correctly in certain complex scenarios.

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product/Type/Configurable.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product/Type/Configurable.php
@@ -243,6 +243,8 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product_Type_Configurable
                         'use_default' => 1,
                         'value'       => $attrParams['frontend_label']
                     );
+                } elseif (isset($superAttributes['attributes'][$productId][$attrParams['id']]['product_super_attribute_id'])) {
+                    $productSuperAttrId = $superAttributes['attributes'][$productId][$attrParams['id']]['product_super_attribute_id'];
                 }
                 if (isset($rowData['_super_attribute_option']) && strlen($rowData['_super_attribute_option'])) {
                     $optionId = $attrParams['options'][Mage::helper('fastsimpleimport')->strtolower($rowData['_super_attribute_option'])];


### PR DESCRIPTION
We encountered scenarios where the configurable was not imported 100% correctly. The problem would should on the backend as the _super_attribute_price_corr field being empty and type set to Fixed.

![image](https://user-images.githubusercontent.com/7595296/43086715-51283378-8e9e-11e8-800b-1bf43db99594.png)

Reproduction:
1. Create 2 select attributes, usable for configs, with 2 different values each (example: durchfluss - 5,0 and 8,0 - rueckflussverhinderer - Nein and "Ja, halb"
2. Create 4 simple products, each having a unique combination of the 4 attribute values
3. Import a config which is supposed to include all of them via CSV shell/import.php

> sku,_type,_attribute_set,_product_websites,name,description,price,status,visibility,tax_class_id,qty,short_description,_super_products_sku,_super_attribute_code,_super_attribute_option,_super_attribute_price_corr
> testconfig,configurable,Default,base,Tolles Config,Confg super!,3.45,1,4,2,1337,Bla Blubb tolles Produkt,durchflussbegrenzerNein5l,durchfluss,"5,0",100.0000%
> ,,,,,,,,,,,,durchflussbegrenzerNein5l,rueckflussverhinderer,Nein,100.0000%
> ,,,,,,,,,,,,durchflussbegrenzerJa5l,durchfluss,"5,0",100.0000%
> ,,,,,,,,,,,,durchflussbegrenzerJa5l,rueckflussverhinderer,"Ja, halb",100.0000%
> ,,,,,,,,,,,,durchflussbegrenzerNein8l,durchfluss,"8,0",100.0000%
> ,,,,,,,,,,,,durchflussbegrenzerNein8l,rueckflussverhinderer,Nein,100.0000%
> ,,,,,,,,,,,,durchflussbegrenzerJa8L,durchfluss,"8,0",100.0000%
> ,,,,,,,,,,,,durchflussbegrenzerJa8L,rueckflussverhinderer,"Ja, halb",100.0000%

Expected result:
![image](https://user-images.githubusercontent.com/7595296/43086911-d002c898-8e9e-11e8-9ae8-aa99618fe358.png)

Actual result see screenshot above.

The problem seemed to be related to the specific order in which the super attribute values were supplied. In different order the problem might not occur.
The fix should take care of that.