### PR TITLE
fixed import of unicode attribute options

### DIFF
--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Category.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Category.php
@@ -1480,4 +1480,43 @@ class AvS_FastSimpleImport_Model_Import_Entity_Category extends Mage_ImportExpor
     {
         return $this->getCategoriesWithRoots();
     }
+
+    /**
+     * Returns attributes all values in label-value or value-value pairs form. Labels are lower-cased.
+     *
+     * @param Mage_Eav_Model_Entity_Attribute_Abstract $attribute
+     * @param array $indexValAttrs OPTIONAL Additional attributes' codes with index values.
+     * @return array
+     */
+    public function getAttributeOptions(Mage_Eav_Model_Entity_Attribute_Abstract $attribute, $indexValAttrs = array())
+    {
+        $options = array();
+
+        if ($attribute->usesSource()) {
+            // merge global entity index value attributes
+            $indexValAttrs = array_merge($indexValAttrs, $this->_indexValueAttributes);
+
+            // should attribute has index (option value) instead of a label?
+            $index = in_array($attribute->getAttributeCode(), $indexValAttrs) ? 'value' : 'label';
+
+            // only default (admin) store values used
+            $attribute->setStoreId(Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID);
+
+            try {
+                /** @var AvS_FastSimpleImport_Helper_Data $helper */
+                $helper = Mage::helper('fastsimpleimport');
+                foreach ($attribute->getSource()->getAllOptions(false) as $option) {
+                    $value = is_array($option['value']) ? $option['value'] : array($option);
+                    foreach ($value as $innerOption) {
+                        if (strlen($innerOption['value'])) { // skip ' -- Please Select -- ' option
+                            $options[$helper->strtolower($innerOption[$index])] = $innerOption['value'];
+                        }
+                    }
+                }
+            } catch (Exception $e) {
+                // ignore exceptions connected with source models
+            }
+        }
+        return $options;
+    }
 }

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Customer.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Customer.php
@@ -703,4 +703,43 @@ class AvS_FastSimpleImport_Model_Import_Entity_Customer extends Mage_ImportExpor
     {
         return $this->_oldCustomers;
     }
+
+    /**
+     * Returns attributes all values in label-value or value-value pairs form. Labels are lower-cased.
+     *
+     * @param Mage_Eav_Model_Entity_Attribute_Abstract $attribute
+     * @param array $indexValAttrs OPTIONAL Additional attributes' codes with index values.
+     * @return array
+     */
+    public function getAttributeOptions(Mage_Eav_Model_Entity_Attribute_Abstract $attribute, $indexValAttrs = array())
+    {
+        $options = array();
+
+        if ($attribute->usesSource()) {
+            // merge global entity index value attributes
+            $indexValAttrs = array_merge($indexValAttrs, $this->_indexValueAttributes);
+
+            // should attribute has index (option value) instead of a label?
+            $index = in_array($attribute->getAttributeCode(), $indexValAttrs) ? 'value' : 'label';
+
+            // only default (admin) store values used
+            $attribute->setStoreId(Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID);
+
+            try {
+                /** @var AvS_FastSimpleImport_Helper_Data $helper */
+                $helper = Mage::helper('fastsimpleimport');
+                foreach ($attribute->getSource()->getAllOptions(false) as $option) {
+                    $value = is_array($option['value']) ? $option['value'] : array($option);
+                    foreach ($value as $innerOption) {
+                        if (strlen($innerOption['value'])) { // skip ' -- Please Select -- ' option
+                            $options[$helper->strtolower($innerOption[$index])] = $innerOption['value'];
+                        }
+                    }
+                }
+            } catch (Exception $e) {
+                // ignore exceptions connected with source models
+            }
+        }
+        return $options;
+    }
 }

--- a/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
+++ b/src/app/code/community/AvS/FastSimpleImport/Model/Import/Entity/Product.php
@@ -2210,4 +2210,43 @@ class AvS_FastSimpleImport_Model_Import_Entity_Product extends AvS_FastSimpleImp
         }
         return false;
     }
+
+    /**
+     * Returns attributes all values in label-value or value-value pairs form. Labels are lower-cased.
+     *
+     * @param Mage_Eav_Model_Entity_Attribute_Abstract $attribute
+     * @param array $indexValAttrs OPTIONAL Additional attributes' codes with index values.
+     * @return array
+     */
+    public function getAttributeOptions(Mage_Eav_Model_Entity_Attribute_Abstract $attribute, $indexValAttrs = array())
+    {
+        $options = array();
+
+        if ($attribute->usesSource()) {
+            // merge global entity index value attributes
+            $indexValAttrs = array_merge($indexValAttrs, $this->_indexValueAttributes);
+
+            // should attribute has index (option value) instead of a label?
+            $index = in_array($attribute->getAttributeCode(), $indexValAttrs) ? 'value' : 'label';
+
+            // only default (admin) store values used
+            $attribute->setStoreId(Mage_Catalog_Model_Abstract::DEFAULT_STORE_ID);
+
+            try {
+                /** @var AvS_FastSimpleImport_Helper_Data $helper */
+                $helper = Mage::helper('fastsimpleimport');
+                foreach ($attribute->getSource()->getAllOptions(false) as $option) {
+                    $value = is_array($option['value']) ? $option['value'] : array($option);
+                    foreach ($value as $innerOption) {
+                        if (strlen($innerOption['value'])) { // skip ' -- Please Select -- ' option
+                            $options[$helper->strtolower($innerOption[$index])] = $innerOption['value'];
+                        }
+                    }
+                }
+            } catch (Exception $e) {
+                // ignore exceptions connected with source models
+            }
+        }
+        return $options;
+    }
 }


### PR DESCRIPTION
This is another place where we need to replace the default `strtolower` method with our special one, which uses `mb_strtolower` if available.

This is a follow-up of PR #395.